### PR TITLE
Reset Tom speech state on restart

### DIFF
--- a/js/tom.js
+++ b/js/tom.js
@@ -17,6 +17,13 @@ export function initTom(img, tileSize) {
     tom.image = img;
     tom.x = 10 * tileSize;
     tom.y = 2 * tileSize;
+
+    // Reset speech state so Tom can move immediately after a restart
+    speaking = false;
+    if (speechTimer) {
+        clearTimeout(speechTimer);
+        speechTimer = null;
+    }
 }
 
 export function moveTom(path, tileSize) {


### PR DESCRIPTION
## Summary
- Clear Tom Riddle's speech timer and flag when initializing to prevent him from freezing after a restart.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890f75fe9c0832b97b286907369f02e