### PR TITLE
style restart button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -21,10 +21,25 @@ body {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    padding: 12px 24px;
+    padding: 12px 48px 12px 72px;
     font-size: 18px;
+    font-family: inherit;
     cursor: pointer;
     z-index: 10;
+    background-color: #222;
+    border: 2px solid #d4af37;
+    color: #d4af37;
+    border-radius: 8px;
+    background-image: url('../assets/ring.png');
+    background-repeat: no-repeat;
+    background-size: 32px 32px;
+    background-position: 20px center;
+    transition: background-color 0.3s, transform 0.3s;
+}
+
+#restartBtn:hover {
+    background-color: #333;
+    transform: translate(-50%, -50%) scale(1.05);
 }
 
 #tomSpeech {


### PR DESCRIPTION
## Summary
- restyle Restart button with dark theme, gold accents, and hover transitions
- include ring icon and maintain centered overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890f9da1e70832bba0daa886161fd27