### PR TITLE
feat: move tom autonomously

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -12,6 +12,8 @@ let wallImage, floorImage, harryImage, tomImage;
 let snakeImage, diademImage, diaryImage, locketImage, ringImage
 let winImage, loseImage;
 let restartBtn;
+let tomInterval;
+const tomSpeed = 2;
 
 window.onload = () => {
   canvas = document.getElementById('gameCanvas');
@@ -64,6 +66,7 @@ function assetLoaded() {
     generateHorcruxes([snakeImage, diademImage, diaryImage, ringImage, locketImage], map);
     draw();
     setupControls();
+    startTomLoop();
   }
 }
 
@@ -95,6 +98,17 @@ if (moved) {
   if (allCollected) {
     gameState = 'win';
   }
+  if (tom.x === player.x && tom.y === player.y) {
+    gameState = 'lose';
+  }
+    draw();
+  }
+}
+
+function startTomLoop() {
+  if (tomInterval) clearInterval(tomInterval);
+  tomInterval = setInterval(() => {
+    if (gameState !== 'playing') return;
     const path = findPath(
       Math.floor(tom.x / tileSize),
       Math.floor(tom.y / tileSize),
@@ -102,17 +116,13 @@ if (moved) {
       Math.floor(player.y / tileSize),
       map
     );
-
-    moveTom(path, tileSize);
-
+    moveTom(path, tileSize, tomSpeed);
     if (tom.x === player.x && tom.y === player.y) {
       gameState = 'lose';
     }
-
     draw();
-  }
+  }, 300);
 }
-
 function draw() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   drawMap(ctx, tileSize, wallImage, floorImage);

--- a/js/tom.js
+++ b/js/tom.js
@@ -26,9 +26,9 @@ export function initTom(img, tileSize) {
     }
 }
 
-export function moveTom(path, tileSize) {
+export function moveTom(path, tileSize, steps = 1) {
     if (speaking || path.length === 0) return;
-    const step = path[0];
+    const step = path[Math.min(steps - 1, path.length - 1)];
     tom.x = step.col * tileSize;
     tom.y = step.row * tileSize;
 }


### PR DESCRIPTION
## Summary
- make Tom chase Harry every tick and recalc path regardless of player input
- allow Tom to move multiple tiles per update to increase speed
- check for player collision after both player and Tom move

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890fc1e6dcc832bafa0ebcbe8bc8616