### PR TITLE
Hide Tom's speech after win or loss

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1,7 +1,7 @@
 import { map, drawMap } from './map.js';
 import { player } from './player.js';
 import { horcruxes, generateHorcruxes, drawHorcruxes, checkPickup } from './horcruxManager.js';
-import { tom, initTom, moveTom, drawTom, sayTomQuote, updateSpeechPosition } from './tom.js';
+import { tom, initTom, moveTom, drawTom, sayTomQuote, updateSpeechPosition, stopTomSpeech } from './tom.js';
 import { findPath } from './pathfinding.js';
 
 let canvas, ctx;
@@ -41,9 +41,7 @@ window.onload = () => {
     gameState = 'playing';
     restartBtn.style.display = 'none';
 
-    // Скрываем фразу Тома если он говорит
-    const tomSpeech = document.getElementById('tomSpeech');
-    tomSpeech.style.display = 'none';
+    stopTomSpeech();
 
   draw();
 });
@@ -133,9 +131,11 @@ function draw() {
 
 
   if (gameState === 'win') {
+    stopTomSpeech();
     ctx.drawImage(winImage, 0, 0, canvas.width, canvas.height);
     restartBtn.style.display = 'block';
   } else if (gameState === 'lose') {
+    stopTomSpeech();
     ctx.drawImage(loseImage, 0, 0, canvas.width, canvas.height);
     restartBtn.style.display = 'block';
   } else {

--- a/js/tom.js
+++ b/js/tom.js
@@ -68,3 +68,15 @@ export function updateSpeechPosition(canvas, tileSize) {
     div.style.left = `${sx}px`;
     div.style.top = `${sy}px`;
 }
+
+export function stopTomSpeech() {
+    const div = document.getElementById('tomSpeech');
+    if (div) {
+        div.style.display = 'none';
+    }
+    if (speechTimer) {
+        clearTimeout(speechTimer);
+        speechTimer = null;
+    }
+    speaking = false;
+}


### PR DESCRIPTION
## Summary
- add utility to halt Tom's dialog
- stop Tom's dialog when the player wins, loses, or restarts the game

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890fe0b72dc832b932e2dec94ff4d21