### PR TITLE
Add particle effects for character movement

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -3,6 +3,7 @@ import { player } from './player.js';
 import { horcruxes, generateHorcruxes, drawHorcruxes, checkPickup } from './horcruxManager.js';
 import { tom, initTom, moveTom, drawTom, sayTomQuote, updateSpeechPosition, stopTomSpeech } from './tom.js';
 import { findPath } from './pathfinding.js';
+import { updateAndDrawParticles } from './particle.js';
 
 let canvas, ctx;
 const tileSize = 58;
@@ -42,9 +43,7 @@ window.onload = () => {
     restartBtn.style.display = 'none';
 
     stopTomSpeech();
-
-  draw();
-});
+  });
 };
 
 
@@ -62,9 +61,9 @@ function assetLoaded() {
     player.init(harryImage, tileSize);
     initTom(tomImage, tileSize);
     generateHorcruxes([snakeImage, diademImage, diaryImage, ringImage, locketImage], map);
-    draw();
     setupControls();
     startTomLoop();
+    requestAnimationFrame(loop);
   }
 }
 
@@ -99,7 +98,6 @@ if (moved) {
   if (tom.x === player.x && tom.y === player.y) {
     gameState = 'lose';
   }
-    draw();
   }
 }
 
@@ -118,7 +116,6 @@ function startTomLoop() {
     if (tom.x === player.x && tom.y === player.y) {
       gameState = 'lose';
     }
-    draw();
   }, 300);
 }
 function draw() {
@@ -127,6 +124,7 @@ function draw() {
   drawHorcruxes(ctx, tileSize);
   player.draw(ctx, tileSize);
   drawTom(ctx, tileSize);
+  updateAndDrawParticles(ctx);
   updateSpeechPosition(canvas, tileSize);
 
 
@@ -141,5 +139,10 @@ function draw() {
   } else {
     restartBtn.style.display = 'none';
   }
+}
+
+function loop() {
+  draw();
+  requestAnimationFrame(loop);
 }
 

--- a/js/particle.js
+++ b/js/particle.js
@@ -1,0 +1,56 @@
+export class Particle {
+  constructor(x, y, vx, vy, color, lifetime = 60) {
+    this.x = x;
+    this.y = y;
+    this.vx = vx;
+    this.vy = vy;
+    this.color = color;
+    this.lifetime = lifetime;
+    this.alpha = 1;
+    this.initialLife = lifetime;
+  }
+
+  update() {
+    this.x += this.vx;
+    this.y += this.vy;
+    this.lifetime--;
+    this.alpha = this.lifetime / this.initialLife;
+  }
+
+  draw(ctx) {
+    ctx.save();
+    ctx.globalAlpha = this.alpha;
+    ctx.fillStyle = this.color;
+    ctx.beginPath();
+    ctx.arc(this.x, this.y, 3, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+  }
+}
+
+export const particles = [];
+
+export function spawnParticles(x, y, character) {
+  const colors = character === 'tom' ? ['green', 'silver'] : ['red', 'gold'];
+  for (let i = 0; i < 8; i++) {
+    const angle = Math.random() * Math.PI * 2;
+    const speed = Math.random() * 2 + 0.5;
+    const vx = Math.cos(angle) * speed;
+    const vy = Math.sin(angle) * speed;
+    const color = colors[Math.floor(Math.random() * colors.length)];
+    particles.push(new Particle(x, y, vx, vy, color));
+  }
+}
+
+export function updateAndDrawParticles(ctx) {
+  for (let i = particles.length - 1; i >= 0; i--) {
+    const p = particles[i];
+    p.update();
+    if (p.lifetime <= 0) {
+      particles.splice(i, 1);
+    } else {
+      p.draw(ctx);
+    }
+  }
+}
+

--- a/js/player.js
+++ b/js/player.js
@@ -1,3 +1,5 @@
+import { spawnParticles } from './particle.js';
+
 export const player = {
   x: null,
   y: null,
@@ -11,8 +13,11 @@ export const player = {
     const nx = this.x + dx, ny = this.y + dy;
     const col = Math.floor(nx / tileSize), row = Math.floor(ny / tileSize);
     if (map[row]?.[col] === 0) {
+      const px = this.x + tileSize / 2;
+      const py = this.y + tileSize / 2;
       this.x = nx;
       this.y = ny;
+      spawnParticles(px, py, 'harry');
       return { col, row };
     }
     return null;

--- a/js/tom.js
+++ b/js/tom.js
@@ -1,3 +1,5 @@
+import { spawnParticles } from './particle.js';
+
 export const tom = { x: null, y: null, image: null };
 
 const quotes = [
@@ -28,9 +30,12 @@ export function initTom(img, tileSize) {
 
 export function moveTom(path, tileSize, steps = 1) {
     if (speaking || path.length === 0) return;
+    const prevX = tom.x + tileSize / 2;
+    const prevY = tom.y + tileSize / 2;
     const step = path[Math.min(steps - 1, path.length - 1)];
     tom.x = step.col * tileSize;
     tom.y = step.row * tileSize;
+    spawnParticles(prevX, prevY, 'tom');
 }
 
 export function drawTom(ctx, tileSize) {


### PR DESCRIPTION
## Summary
- Implement a reusable particle system with fading lifetime and color-coded trails
- Emit colored particles for Harry and Tom when they move
- Continuously update and render particle effects each frame

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891009f1970832bb1e10da2955fd5fe