### PR TITLE
Implement smooth easing movement

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -3,20 +3,45 @@ import { spawnParticles } from './particle.js';
 export const player = {
   x: null,
   y: null,
+  targetX: null,
+  targetY: null,
+  isMoving: false,
   image: null,
   init(img, tileSize) {
     this.image = img;
-    this.x = tileSize;
-    this.y = tileSize;
+    this.x = this.targetX = tileSize;
+    this.y = this.targetY = tileSize;
+    this.isMoving = false;
   },
   move(dx, dy, tileSize, map) {
+    if (this.isMoving) return null;
     const nx = this.x + dx, ny = this.y + dy;
     const col = Math.floor(nx / tileSize), row = Math.floor(ny / tileSize);
     if (map[row]?.[col] === 0) {
       const px = this.x + tileSize / 2;
       const py = this.y + tileSize / 2;
-      this.x = nx;
-      this.y = ny;
+      this.targetX = nx;
+      this.targetY = ny;
+      this.isMoving = true;
+      const startX = this.x;
+      const startY = this.y;
+      const startTime = performance.now();
+      const duration = 200;
+      const animate = (time) => {
+        const elapsed = time - startTime;
+        let t = Math.min(elapsed / duration, 1);
+        t = t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+        this.x = startX + (this.targetX - startX) * t;
+        this.y = startY + (this.targetY - startY) * t;
+        if (elapsed < duration) {
+          requestAnimationFrame(animate);
+        } else {
+          this.x = this.targetX;
+          this.y = this.targetY;
+          this.isMoving = false;
+        }
+      };
+      requestAnimationFrame(animate);
       spawnParticles(px, py, 'harry');
       return { col, row };
     }

--- a/js/tom.js
+++ b/js/tom.js
@@ -1,6 +1,6 @@
 import { spawnParticles } from './particle.js';
 
-export const tom = { x: null, y: null, image: null };
+export const tom = { x: null, y: null, targetX: null, targetY: null, isMoving: false, image: null };
 
 const quotes = [
     "Отдай это, Поттер.",
@@ -17,8 +17,9 @@ let speechTimer = null;
 
 export function initTom(img, tileSize) {
     tom.image = img;
-    tom.x = 10 * tileSize;
-    tom.y = 2 * tileSize;
+    tom.x = tom.targetX = 10 * tileSize;
+    tom.y = tom.targetY = 2 * tileSize;
+    tom.isMoving = false;
 
     // Reset speech state so Tom can move immediately after a restart
     speaking = false;
@@ -29,12 +30,32 @@ export function initTom(img, tileSize) {
 }
 
 export function moveTom(path, tileSize, steps = 1) {
-    if (speaking || path.length === 0) return;
+    if (speaking || tom.isMoving || path.length === 0) return;
     const prevX = tom.x + tileSize / 2;
     const prevY = tom.y + tileSize / 2;
     const step = path[Math.min(steps - 1, path.length - 1)];
-    tom.x = step.col * tileSize;
-    tom.y = step.row * tileSize;
+    tom.targetX = step.col * tileSize;
+    tom.targetY = step.row * tileSize;
+    tom.isMoving = true;
+    const startX = tom.x;
+    const startY = tom.y;
+    const startTime = performance.now();
+    const duration = 200;
+    const animate = (time) => {
+        const elapsed = time - startTime;
+        let t = Math.min(elapsed / duration, 1);
+        t = t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+        tom.x = startX + (tom.targetX - startX) * t;
+        tom.y = startY + (tom.targetY - startY) * t;
+        if (elapsed < duration) {
+            requestAnimationFrame(animate);
+        } else {
+            tom.x = tom.targetX;
+            tom.y = tom.targetY;
+            tom.isMoving = false;
+        }
+    };
+    requestAnimationFrame(animate);
     spawnParticles(prevX, prevY, 'tom');
 }
 


### PR DESCRIPTION
## Summary
- Smoothly animate player and Tom toward target tiles with easing
- Track movement state with target coordinates and `isMoving`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689102587fe4832bad1e2f05f85d3f5f