### PR TITLE
style: add smoky cloud speech bubble for Tom

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -44,13 +44,27 @@ body {
 
 #tomSpeech {
     position: absolute;
-    background: rgba(0,0,0,0.7);
-    color: white;
+    background: radial-gradient(circle at center, #f5f5f5 0%, #d9d9d9 70%, #bcbcbc 100%);
+    color: #333;
     padding: 8px 16px;
-    border-radius: 5px;
+    border-radius: 40px;
+    box-shadow: 0 0 20px rgba(0,0,0,0.3);
     display: none;
     font-size: 16px;
     pointer-events: none;
     z-index: 999;
     white-space: nowrap;
+}
+
+#tomSpeech::after {
+    content: '';
+    position: absolute;
+    bottom: -12px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 24px;
+    height: 24px;
+    background: radial-gradient(circle at center, #e6e6e6 0%, #c7c7c7 70%, transparent 80%);
+    border-radius: 50%;
+    box-shadow: 0 0 15px rgba(0,0,0,0.25);
 }


### PR DESCRIPTION
## Summary
- restyle Tom's speech bubble as a grey smoky cloud with radial gradient, rounded edges, and drop shadow
- add ::after pseudo-element to render a wispy tail

## Testing
- `npm test` *(fails: package.json missing)*
- `python -m http.server` and `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68910800ff1c832bb67e682b25f1a075