### PR TITLE
Style: add diamond pointer to speech bubble

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -59,12 +59,11 @@ body {
 #tomSpeech::after {
     content: '';
     position: absolute;
-    bottom: -12px;
+    bottom: -6px;
     left: 50%;
-    transform: translateX(-50%);
-    width: 24px;
-    height: 24px;
-    background: radial-gradient(circle at center, #e6e6e6 0%, #c7c7c7 70%, transparent 80%);
-    border-radius: 50%;
-    box-shadow: 0 0 15px rgba(0,0,0,0.25);
+    width: 12px;
+    height: 12px;
+    background: radial-gradient(circle at center, #f5f5f5 0%, #d9d9d9 70%, #bcbcbc 100%);
+    transform: translateX(-50%) rotate(45deg);
+    box-shadow: 0 0 10px rgba(0,0,0,0.25);
 }


### PR DESCRIPTION
## Summary
- Restyle Tom's speech bubble tail as a small rotated square matching the bubble's gradient, creating a diamond pointer.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68910c9ad25c832bbd3d46dc62eedcd2