### PR TITLE
Fix duplicate variable declaration in Tom movement

### DIFF
--- a/js/tom.js
+++ b/js/tom.js
@@ -30,15 +30,6 @@ export function initTom(img, tileSize) {
 }
 
 export function moveTom(path, tileSize, steps = 1) {
-    if (speaking || path.length === 0) return;
-    const prevX = tom.x + tileSize / 2;
-    const prevY = tom.y + tileSize / 2;
-    const step = path[Math.min(steps - 1, path.length - 1)];
-    tom.x = step.col * tileSize;
-    tom.y = step.row * tileSize;
-    const newX = tom.x + tileSize / 2;
-    const newY = tom.y + tileSize / 2;
-    spawnParticles(prevX, prevY, 'tom', newX - prevX, newY - prevY);
     if (speaking || tom.isMoving || path.length === 0) return;
     const prevX = tom.x + tileSize / 2;
     const prevY = tom.y + tileSize / 2;
@@ -65,6 +56,9 @@ export function moveTom(path, tileSize, steps = 1) {
         }
     };
     requestAnimationFrame(animate);
+    const newX = tom.targetX + tileSize / 2;
+    const newY = tom.targetY + tileSize / 2;
+    spawnParticles(prevX, prevY, 'tom', newX - prevX, newY - prevY);
 }
 
 export function drawTom(ctx, tileSize) {


### PR DESCRIPTION
## Summary
- remove duplicate variable declarations in `moveTom` to prevent `prevX` redeclaration
- integrate particle trail with smooth Tom movement by spawning particles with movement vector

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/tom.js`


------
https://chatgpt.com/codex/tasks/task_e_6891113555a0832bb45ef324ef05233b