### PR TITLE
Add mobile touch controls and viewport settings

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -13,6 +13,7 @@ body {
 #gameCanvas {
     border: 2px solid #444;
     background-color: #000;
+    touch-action: none;
 }
 
 /* Restart button styling */

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <base href="https://sherhin.github.io/horcrux_chase/">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>Horcrux Chase</title>
     <link rel="stylesheet" href="css/styles.css">
 </head>

--- a/js/game.js
+++ b/js/game.js
@@ -70,6 +70,28 @@ function assetLoaded() {
 
 function setupControls() {
   document.addEventListener('keydown', onKey);
+
+  let startX, startY;
+
+  canvas.addEventListener('touchstart', (e) => {
+    e.preventDefault();
+    const touch = e.touches[0];
+    startX = touch.clientX;
+    startY = touch.clientY;
+  }, { passive: false });
+
+  canvas.addEventListener('touchend', (e) => {
+    e.preventDefault();
+    const touch = e.changedTouches[0];
+    const dx = touch.clientX - startX;
+    const dy = touch.clientY - startY;
+
+    if (Math.abs(dx) > Math.abs(dy)) {
+      onKey({ key: dx > 0 ? 'ArrowRight' : 'ArrowLeft' });
+    } else {
+      onKey({ key: dy > 0 ? 'ArrowDown' : 'ArrowUp' });
+    }
+  }, { passive: false });
 }
 
 function onKey(e) {


### PR DESCRIPTION
## Summary
- support mobile by adding viewport meta tag and disabling default canvas touch actions
- enable swipe gestures on canvas to control the player

## Testing
- `npm test` *(fails: could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689114606370832b8814c8bafafed5ef