### PR TITLE
Add on-screen control pad for touch input

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -69,3 +69,45 @@ body {
     transform: translateX(-50%) rotate(45deg);
     box-shadow: 0 0 10px rgba(0,0,0,0.25);
 }
+
+#controls {
+    position: absolute;
+    bottom: 5vh;
+    right: 5vw;
+    display: grid;
+    grid-template-columns: repeat(3, 8vh);
+    grid-template-rows: repeat(3, 8vh);
+    gap: 1vh;
+    touch-action: manipulation;
+    user-select: none;
+}
+
+#controls button {
+    width: 8vh;
+    height: 8vh;
+    font-size: 4vh;
+    background-color: #222;
+    border: 2px solid #d4af37;
+    color: #d4af37;
+    border-radius: 8px;
+}
+
+#controls button:active {
+    background-color: #333;
+}
+
+#controls .up {
+    grid-area: 1 / 2;
+}
+
+#controls .left {
+    grid-area: 2 / 1;
+}
+
+#controls .down {
+    grid-area: 3 / 2;
+}
+
+#controls .right {
+    grid-area: 2 / 3;
+}

--- a/index.html
+++ b/index.html
@@ -14,6 +14,13 @@
     <button id="restartBtn">Restart</button>
     <div id="tomSpeech"></div>
 
+    <div id="controls">
+        <button data-key="ArrowUp" class="up">&#9650;</button>
+        <button data-key="ArrowLeft" class="left">&#9664;</button>
+        <button data-key="ArrowDown" class="down">&#9660;</button>
+        <button data-key="ArrowRight" class="right">&#9654;</button>
+    </div>
+
     <!-- Подключаем модули -->
     <script type="module" src="js/game.js"></script>
 

--- a/js/game.js
+++ b/js/game.js
@@ -5,6 +5,7 @@ import { tom, initTom, moveTom, drawTom, sayTomQuote, updateSpeechPosition, stop
 import { findPath } from './pathfinding.js';
 import { updateAndDrawParticles } from './particle.js';
 import { generateDementors, drawDementors } from './dementor.js';
+import { initButtonControls } from './ui.js';
 
 let canvas, ctx;
 const tileSize = 58;
@@ -76,6 +77,7 @@ function assetLoaded() {
 
 function setupControls() {
   document.addEventListener('keydown', onKey);
+  initButtonControls(onKey);
 
   let startX, startY;
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,14 @@
+
+export function initButtonControls(onKey) {
+  const controls = document.getElementById('controls');
+  if (!controls) return;
+
+  controls.querySelectorAll('button').forEach((btn) => {
+    btn.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      const key = btn.dataset.key;
+      onKey({ key });
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- Add a directional control pad to the HTML for on-screen navigation
- Style control pad with responsive vh/vw layout near screen edge
- Convert button presses to Arrow key events and initialize them in game setup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68911ec1cd98832b9a41662af9ad720b