### PR TITLE
Make canvas responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 
-    <canvas id="gameCanvas" width="700" height="812"></canvas>
+    <canvas id="gameCanvas"></canvas>
 
     <button id="restartBtn">Restart</button>
     <div id="tomSpeech"></div>


### PR DESCRIPTION
## Summary
- remove fixed canvas size for responsive layout
- compute tile size from viewport and map dimensions
- handle canvas resizing, scaling entities and restart logic

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68911ebde6c4832bb042c542967c6df9