### PR TITLE
Prevent player movement onto dementor tiles

### DIFF
--- a/js/dementor.js
+++ b/js/dementor.js
@@ -20,3 +20,7 @@ export function drawDementors(ctx, tileSize) {
     ctx.drawImage(d.image, d.x * tileSize, d.y * tileSize, tileSize, tileSize);
   });
 }
+
+export function getDementors() {
+  return dementors;
+}

--- a/js/player.js
+++ b/js/player.js
@@ -1,4 +1,5 @@
 import { spawnParticles } from './particle.js';
+import { getDementors } from './dementor.js';
 
 const MOVE_DURATION = 100;
 
@@ -20,6 +21,8 @@ export const player = {
     const nx = this.x + dx, ny = this.y + dy;
     const col = Math.floor(nx / tileSize), row = Math.floor(ny / tileSize);
     if (map[row]?.[col] === 0) {
+      const occupied = getDementors().some(d => d.x === col && d.y === row);
+      if (occupied) return null;
       const px = this.x + tileSize / 2;
       const py = this.y + tileSize / 2;
       this.x = nx;


### PR DESCRIPTION
## Summary
- export `getDementors` helper to expose active dementors
- block `player.move` when the destination tile contains a dementor

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689121044890832bb5464001c808534f