### PR TITLE
Improve canvas scaling on different screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <base href="https://sherhin.github.io/horcrux_chase/">
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Horcrux Chase</title>
     <link rel="stylesheet" href="css/styles.css">
 </head>

--- a/js/game.js
+++ b/js/game.js
@@ -23,6 +23,7 @@ const tomSpeed = 1;
 function resizeCanvas() {
   const cols = map[0].length;
   const rows = map.length;
+  const dpr = window.devicePixelRatio || 1;
   const newTileSize = Math.min(window.innerWidth / cols, window.innerHeight / rows);
   if (tileSize) {
     const scale = newTileSize / tileSize;
@@ -44,8 +45,11 @@ function resizeCanvas() {
     });
   }
   tileSize = newTileSize;
-  canvas.width = tileSize * cols;
-  canvas.height = tileSize * rows;
+  canvas.style.width = `${tileSize * cols}px`;
+  canvas.style.height = `${tileSize * rows}px`;
+  canvas.width = tileSize * cols * dpr;
+  canvas.height = tileSize * rows * dpr;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   if (assetsLoaded === TOTAL_ASSETS) {
     draw();
   }


### PR DESCRIPTION
## Summary
- allow viewport zoom by removing user-scalable restriction
- handle device pixel ratio and set canvas style size for sharper rendering

## Testing
- `node --check js/game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689121ce588c832b851e1dcead7ad1b6