### PR TITLE
fix: remove duplicate getDementors function

### DIFF
--- a/js/dementor.js
+++ b/js/dementor.js
@@ -99,7 +99,3 @@ export function drawDementors(ctx, tileSize) {
     ctx.drawImage(d.image, d.x, d.y, tileSize, tileSize);
   });
 }
-
-export function getDementors() {
-  return dementors;
-}


### PR DESCRIPTION
## Summary
- remove duplicate `getDementors` declaration to stop redeclaration error

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_689123051cd8832b9c74070135d59cf6