### PR TITLE
Scale win/lose overlays to game screen

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -197,13 +197,17 @@ function draw() {
   updateSpeechPosition(canvas, tileSize);
 
 
+  const dpr = window.devicePixelRatio || 1;
+  const displayWidth = canvas.width / dpr;
+  const displayHeight = canvas.height / dpr;
+
   if (gameState === 'win') {
     stopTomSpeech();
-    ctx.drawImage(winImage, 0, 0, canvas.width, canvas.height);
+    ctx.drawImage(winImage, 0, 0, displayWidth, displayHeight);
     restartBtn.style.display = 'block';
   } else if (gameState === 'lose') {
     stopTomSpeech();
-    ctx.drawImage(loseImage, 0, 0, canvas.width, canvas.height);
+    ctx.drawImage(loseImage, 0, 0, displayWidth, displayHeight);
     restartBtn.style.display = 'block';
   } else {
     restartBtn.style.display = 'none';


### PR DESCRIPTION
## Summary
- Use device pixel ratio to calculate canvas display size
- Scale win/lose splash images to fit the canvas dimensions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68912cc3de58832bae3582407c7e693b