### PR TITLE
Handle dementor collision only once

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -187,16 +187,28 @@ function startTomLoop() {
   }, 300);
 }
 
+const activeDementorCollisions = new Set();
+
 function checkDementorCollision() {
+  if (gameState !== 'playing') return;
+
   const playerCol = Math.floor(player.x / tileSize);
   const playerRow = Math.floor(player.y / tileSize);
   const px = player.x + tileSize / 2;
   const py = player.y + tileSize / 2;
+
   getDementors().forEach(d => {
     const dCol = Math.floor(d.x / tileSize);
     const dRow = Math.floor(d.y / tileSize);
+
     if (dCol === playerCol && dRow === playerRow) {
-      spawnParticles(px, py, 'harry');
+      if (!activeDementorCollisions.has(d)) {
+        activeDementorCollisions.add(d);
+        spawnParticles(px, py, 'harry');
+        gameState = 'lose';
+      }
+    } else {
+      activeDementorCollisions.delete(d);
     }
   });
 }


### PR DESCRIPTION
## Summary
- Track dementor collisions in a Set to prevent repeated particle spawns
- Mark game as lost on initial collision and ignore subsequent frames until separated

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68913439fc04832b9de00fdf7b8e6b34