### PR TITLE
Add dementor generation and movement tests

### DIFF
--- a/tests/dementor.test.js
+++ b/tests/dementor.test.js
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { generateDementors, updateDementors, getDementors } from '../js/dementor.js';
+
+test('generateDementors creates three dementors on free tiles without overlap', () => {
+  const originalRandom = Math.random;
+  const originalNow = performance.now;
+
+  try {
+    const randomValues = [0, 0, 0.4, 0, 0.8, 0];
+    let randIndex = 0;
+    Math.random = () => randomValues[randIndex++];
+
+    const perfValues = [0, 0, 0];
+    let perfIndex = 0;
+    performance.now = () => perfValues[perfIndex++];
+
+    const map = [
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0]
+    ];
+    const tileSize = 10;
+    const image = {};
+
+    generateDementors(image, map, tileSize);
+    const dementors = getDementors();
+
+    assert.equal(dementors.length, 3);
+    const positions = dementors.map(d => [d.x / tileSize, d.y / tileSize]);
+    const unique = new Set(positions.map(p => p.toString()));
+    assert.equal(unique.size, 3);
+    positions.forEach(([c, r]) => {
+      assert.equal(map[r][c], 0);
+    });
+  } finally {
+    Math.random = originalRandom;
+    performance.now = originalNow;
+  }
+});
+
+test('updateDementors moves dementors to adjacent free cells without collisions after 1000ms', () => {
+  const originalRandom = Math.random;
+  const originalNow = performance.now;
+  const originalRAF = global.requestAnimationFrame;
+
+  try {
+    const randomValues = [0, 0, 0.4, 0, 0.8, 0];
+    let randIndex = 0;
+    Math.random = () => randomValues[randIndex++] ?? 0;
+
+    const perfValues = [0, 0, 0, 1000, 1000, 1600, 1000, 1600, 1000, 1600];
+    let perfIndex = 0;
+    let lastPerf = 0;
+    performance.now = () => {
+      lastPerf = perfValues[perfIndex++];
+      return lastPerf;
+    };
+    global.requestAnimationFrame = (cb) => cb(lastPerf + 600);
+
+    const map = [
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0]
+    ];
+    const tileSize = 10;
+    const image = {};
+
+    generateDementors(image, map, tileSize);
+    const before = getDementors().map(d => [d.x / tileSize, d.y / tileSize]);
+
+    updateDementors(tileSize, map);
+    const after = getDementors().map(d => [d.x / tileSize, d.y / tileSize]);
+
+    const unique = new Set(after.map(p => p.toString()));
+    assert.equal(unique.size, after.length);
+
+    before.forEach(([c, r], i) => {
+      const [nc, nr] = after[i];
+      const manhattan = Math.abs(nc - c) + Math.abs(nr - r);
+      assert.equal(manhattan, 1);
+      assert.equal(map[nr][nc], 0);
+    });
+  } finally {
+    Math.random = originalRandom;
+    performance.now = originalNow;
+    global.requestAnimationFrame = originalRAF;
+  }
+});


### PR DESCRIPTION
## Summary
- add node-based tests for dementor generation on free, unique tiles
- verify dementor movement after 1s delay stays in adjacent free cells and avoids collisions

## Testing
- `node --test tests/dementor.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68913662774c832b8bf08bda333a9f17