### PR TITLE
Avoid spawning horcrux on player start

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -80,7 +80,11 @@ window.onload = () => {
   restartBtn.addEventListener('click', () => {
     player.init(harryImage, tileSize);
     initTom(tomImage, tileSize);
-    generateHorcruxes([snakeImage, diademImage, diaryImage, locketImage, ringImage], map);
+    generateHorcruxes(
+      [snakeImage, diademImage, diaryImage, locketImage, ringImage],
+      map,
+      [{ x: Math.floor(player.x / tileSize), y: Math.floor(player.y / tileSize) }]
+    );
     generateDementors(dementorImage, map, tileSize);
 
     gameState = 'playing';
@@ -104,7 +108,11 @@ function assetLoaded() {
   if (assetsLoaded === TOTAL_ASSETS) {
     player.init(harryImage, tileSize);
     initTom(tomImage, tileSize);
-    generateHorcruxes([snakeImage, diademImage, diaryImage, ringImage, locketImage], map);
+    generateHorcruxes(
+      [snakeImage, diademImage, diaryImage, ringImage, locketImage],
+      map,
+      [{ x: Math.floor(player.x / tileSize), y: Math.floor(player.y / tileSize) }]
+    );
     generateDementors(dementorImage, map, tileSize);
     setupControls();
     startTomLoop();

--- a/js/horcruxManager.js
+++ b/js/horcruxManager.js
@@ -1,13 +1,17 @@
 export let horcruxes = [];
 
-export function generateHorcruxes(templates, map) {
+export function generateHorcruxes(templates, map, forbidden = []) {
   horcruxes = [];
   templates.forEach(img => {
     let x, y;
     do {
       x = Math.floor(Math.random() * map[0].length);
       y = Math.floor(Math.random() * map.length);
-    } while (map[y][x] !== 0 || horcruxes.some(h => h.x === x && h.y === y));
+    } while (
+      map[y][x] !== 0 ||
+      horcruxes.some(h => h.x === x && h.y === y) ||
+      forbidden.some(p => p.x === x && p.y === y)
+    );
     horcruxes.push({ image: img, x, y });
   });
 }


### PR DESCRIPTION
## Summary
- prevent horcruxes from spawning on the player's starting tile by allowing generateHorcruxes to accept forbidden positions
- pass player's tile position when generating horcruxes on load and restart

## Testing
- `npm test` *(fails: could not find a package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689136571b0c832ba5613905962beaeb