### PR TITLE
Fix grid alignment for player movement

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -18,8 +18,12 @@ export const player = {
   },
   move(dx, dy, tileSize, map) {
     if (this.isMoving) return null;
-    const nx = this.x + dx, ny = this.y + dy;
-    const col = Math.floor(nx / tileSize), row = Math.floor(ny / tileSize);
+    const tentativeX = this.x + dx;
+    const tentativeY = this.y + dy;
+    const col = Math.round(tentativeX / tileSize);
+    const row = Math.round(tentativeY / tileSize);
+    const nx = col * tileSize;
+    const ny = row * tileSize;
     if (map[row]?.[col] === 0) {
       const occupied = getDementors().some(d => {
         const currentCol = Math.floor(d.x / tileSize);

--- a/tests/player.test.js
+++ b/tests/player.test.js
@@ -81,4 +81,13 @@ describe('player.move', () => {
     assert.strictEqual(player.isMoving, false);
     assert.strictEqual(spawnParticlesMock.mock.callCount(), 1);
   });
+
+  it('aligns to grid when starting slightly off it', () => {
+    player.x = tileSize - 0.3;
+    player.y = tileSize;
+    const result = player.move(tileSize, 0, tileSize, emptyMap);
+    assert.deepStrictEqual(result, { col: 2, row: 1 });
+    assert.strictEqual(player.x, tileSize * 2);
+    assert.strictEqual(player.y, tileSize);
+  });
 });


### PR DESCRIPTION
## Summary
- Round movement to nearest tile and snap player position to grid
- Add regression test ensuring off-grid positions align to tiles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891c51e3b60832bbcf2e87d6c7ab073