### PR TITLE
feat: prevent close spawns for horcruxes and dementors

### DIFF
--- a/js/dementor.js
+++ b/js/dementor.js
@@ -4,7 +4,19 @@ export function getDementors() {
   return dementors;
 }
 
-export function generateDementors(image, map, tileSize) {
+function isTooClose(col, row, arr, minDistance, tileSize) {
+  return arr.some(d => {
+    const dc = Math.floor(d.x / tileSize);
+    const dr = Math.floor(d.y / tileSize);
+    return Math.abs(dc - col) + Math.abs(dr - row) < minDistance;
+  });
+}
+
+function isTooClosePoints(col, row, points, minDistance) {
+  return points.some(p => Math.abs(p.x - col) + Math.abs(p.y - row) < minDistance);
+}
+
+export function generateDementors(image, map, tileSize, forbidden = [], minDistance = 1) {
   dementors = [];
   let count = 0;
 
@@ -14,9 +26,12 @@ export function generateDementors(image, map, tileSize) {
 
     const px = col * tileSize;
     const py = row * tileSize;
-    const occupied = dementors.some(d => Math.floor(d.x / tileSize) === col && Math.floor(d.y / tileSize) === row);
 
-    if (map[row][col] === 0 && !occupied) {
+    if (
+      map[row][col] === 0 &&
+      !isTooClose(col, row, dementors, minDistance, tileSize) &&
+      !isTooClosePoints(col, row, forbidden, minDistance)
+    ) {
       dementors.push({
         image,
         x: px,

--- a/js/game.js
+++ b/js/game.js
@@ -19,6 +19,7 @@ let dementorImage;
 let restartBtn;
 let tomInterval;
 const tomSpeed = 1;
+const MIN_DISTANCE = 2;
 
 let winCount = parseInt(sessionStorage.getItem('wins') || '0');
 let loseCount = parseInt(sessionStorage.getItem('losses') || '0');
@@ -105,12 +106,16 @@ window.onload = () => {
   restartBtn.addEventListener('click', () => {
     player.init(harryImage, tileSize);
     initTom(tomImage, tileSize);
+    const startPos = { x: Math.floor(player.x / tileSize), y: Math.floor(player.y / tileSize) };
     generateHorcruxes(
       [snakeImage, diademImage, diaryImage, locketImage, ringImage],
       map,
-      [{ x: Math.floor(player.x / tileSize), y: Math.floor(player.y / tileSize) }]
+      [startPos],
+      MIN_DISTANCE
     );
-    generateDementors(dementorImage, map, tileSize);
+    const forbidden = horcruxes.map(h => ({ x: h.x, y: h.y }));
+    forbidden.push(startPos);
+    generateDementors(dementorImage, map, tileSize, forbidden, MIN_DISTANCE);
 
     setGameState('playing');
     restartBtn.style.display = 'none';
@@ -133,12 +138,16 @@ function assetLoaded() {
   if (assetsLoaded === TOTAL_ASSETS) {
     player.init(harryImage, tileSize);
     initTom(tomImage, tileSize);
+    const startPos = { x: Math.floor(player.x / tileSize), y: Math.floor(player.y / tileSize) };
     generateHorcruxes(
       [snakeImage, diademImage, diaryImage, ringImage, locketImage],
       map,
-      [{ x: Math.floor(player.x / tileSize), y: Math.floor(player.y / tileSize) }]
+      [startPos],
+      MIN_DISTANCE
     );
-    generateDementors(dementorImage, map, tileSize);
+    const forbidden = horcruxes.map(h => ({ x: h.x, y: h.y }));
+    forbidden.push(startPos);
+    generateDementors(dementorImage, map, tileSize, forbidden, MIN_DISTANCE);
     setupControls();
     startTomLoop();
     requestAnimationFrame(loop);

--- a/js/horcruxManager.js
+++ b/js/horcruxManager.js
@@ -1,6 +1,10 @@
 export let horcruxes = [];
 
-export function generateHorcruxes(templates, map, forbidden = []) {
+function isTooClose(x, y, arr, minDistance) {
+  return arr.some(p => Math.abs(p.x - x) + Math.abs(p.y - y) < minDistance);
+}
+
+export function generateHorcruxes(templates, map, forbidden = [], minDistance = 1) {
   horcruxes = [];
   templates.forEach(img => {
     let x, y;
@@ -9,8 +13,8 @@ export function generateHorcruxes(templates, map, forbidden = []) {
       y = Math.floor(Math.random() * map.length);
     } while (
       map[y][x] !== 0 ||
-      horcruxes.some(h => h.x === x && h.y === y) ||
-      forbidden.some(p => p.x === x && p.y === y)
+      isTooClose(x, y, horcruxes, minDistance) ||
+      isTooClose(x, y, forbidden, minDistance)
     );
     horcruxes.push({ image: img, x, y });
   });

--- a/tests/dementor.test.js
+++ b/tests/dementor.test.js
@@ -39,6 +39,50 @@ test('generateDementors creates three dementors on free tiles without overlap', 
   }
 });
 
+test('generateDementors respects forbidden positions and minDistance', () => {
+  const originalRandom = Math.random;
+  const originalNow = performance.now;
+
+  try {
+    const randomValues = [0, 0, 0.5, 0.5, 0, 0.4, 0.8, 0.8, 0, 0, 0.8, 0.4, 0.8, 0];
+    let randIndex = 0;
+    Math.random = () => randomValues[randIndex++];
+
+    const perfValues = [0, 0, 0];
+    let perfIndex = 0;
+    performance.now = () => perfValues[perfIndex++];
+
+    const map = [
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0]
+    ];
+    const tileSize = 10;
+    const image = {};
+
+    generateDementors(image, map, tileSize, [{ x: 1, y: 1 }], 2);
+    const dementors = getDementors();
+
+    assert.equal(dementors.length, 3);
+    const positions = dementors.map(d => [d.x / tileSize, d.y / tileSize]);
+    positions.forEach(([c, r]) => {
+      const distForbidden = Math.abs(c - 1) + Math.abs(r - 1);
+      assert.ok(distForbidden >= 2);
+    });
+    for (let i = 0; i < positions.length; i++) {
+      for (let j = i + 1; j < positions.length; j++) {
+        const [c1, r1] = positions[i];
+        const [c2, r2] = positions[j];
+        const dist = Math.abs(c1 - c2) + Math.abs(r1 - r2);
+        assert.ok(dist >= 2);
+      }
+    }
+  } finally {
+    Math.random = originalRandom;
+    performance.now = originalNow;
+  }
+});
+
 test('updateDementors moves dementors to adjacent free cells without collisions after 1000ms', () => {
   const originalRandom = Math.random;
   const originalNow = performance.now;

--- a/tests/horcruxManager.test.js
+++ b/tests/horcruxManager.test.js
@@ -26,6 +26,33 @@ test('generateHorcruxes places horcruxes only on free tiles without duplicates',
   assert.equal(new Set(coords).size, horcruxes.length);
 });
 
+test('generateHorcruxes respects forbidden positions and minDistance', () => {
+  const sequence = [0, 0, 0.5, 0.5, 0, 0.4, 0.8, 0.9];
+  let index = 0;
+  const originalRandom = Math.random;
+  Math.random = () => sequence[index++];
+
+  const templates = [{ id: 1 }, { id: 2 }];
+  const map = [
+    [0, 0, 0],
+    [0, 0, 0],
+    [0, 0, 0]
+  ];
+
+  const forbidden = [{ x: 1, y: 1 }];
+  generateHorcruxes(templates, map, forbidden, 2);
+  Math.random = originalRandom;
+
+  assert.equal(horcruxes.length, 2);
+  horcruxes.forEach(h => {
+    const distForbidden = Math.abs(h.x - 1) + Math.abs(h.y - 1);
+    assert.ok(distForbidden >= 2);
+  });
+  const [h1, h2] = horcruxes;
+  const dist = Math.abs(h1.x - h2.x) + Math.abs(h1.y - h2.y);
+  assert.ok(dist >= 2);
+});
+
 test('checkPickup removes horcrux, calls callback and returns true when empty', () => {
   horcruxes.length = 0;
   horcruxes.push({ image: {}, x: 1, y: 1 }, { image: {}, x: 2, y: 2 });


### PR DESCRIPTION
## Summary
- ensure horcrux generation keeps distance from each other and forbidden tiles
- prevent dementors from spawning near horcruxes or player start
- wire up min-distance parameters during game initialization and cover with tests

## Testing
- `npm test`
- manual restart of game to verify spacing


------
https://chatgpt.com/codex/tasks/task_e_6891e0ebcfb0832ba157ee7bdd0b59af