### PR TITLE
Add maze generation and dynamic map creation

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1,4 +1,4 @@
-import { map, drawMap } from './map.js';
+import { map, drawMap, generateMap } from './map.js';
 import { player } from './player.js';
 import { horcruxes, generateHorcruxes, drawHorcruxes, checkPickup } from './horcruxManager.js';
 import { tom, initTom, moveTom, drawTom, sayTomQuote, updateSpeechPosition, stopTomSpeech } from './tom.js';
@@ -20,6 +20,8 @@ let restartBtn;
 let tomInterval;
 const tomSpeed = 1;
 const MIN_DISTANCE = 2;
+const MAP_WIDTH = 12;
+const MAP_HEIGHT = 15;
 
 let winCount = parseInt(sessionStorage.getItem('wins') || '0');
 let loseCount = parseInt(sessionStorage.getItem('losses') || '0');
@@ -86,6 +88,7 @@ window.onload = () => {
   loseDisplay = document.getElementById('loseCount');
   updateScoreboard();
 
+  generateMap(MAP_WIDTH, MAP_HEIGHT);
   resizeCanvas();
   window.addEventListener('resize', resizeCanvas);
 
@@ -104,6 +107,8 @@ window.onload = () => {
 
 
   restartBtn.addEventListener('click', () => {
+    generateMap(MAP_WIDTH, MAP_HEIGHT);
+    resizeCanvas();
     player.init(harryImage, tileSize);
     initTom(tomImage, tileSize);
     const startPos = { x: Math.floor(player.x / tileSize), y: Math.floor(player.y / tileSize) };

--- a/js/map.js
+++ b/js/map.js
@@ -1,31 +1,62 @@
-export const map = [
-    [1,1,1,1,1,1,1,1,1,1,1,1],
-    [0,0,0,0,0,0,0,0,1,1,0,1],
-    [0,1,1,1,0,1,1,0,0,1,0,1],
-    [0,1,0,0,0,0,1,0,0,1,0,1],
-    [0,1,0,1,1,0,1,0,0,1,0,1],
-    [0,0,0,0,0,0,1,0,0,0,0,1],
-    [0,0,0,0,0,0,1,0,1,1,0,1],
-    [0,1,1,1,1,0,1,0,1,1,0,1],
-    [0,0,0,0,1,0,0,0,0,0,0,1],
-    [0,1,0,1,1,0,0,0,1,1,0,1],
-    [0,1,0,0,0,0,0,0,0,0,0,1],
-    [0,1,0,1,1,1,0,1,1,0,1,1],
-    [0,0,0,0,0,0,0,0,0,0,1,1],
-    [1,1,1,1,1,1,1,1,1,1,1,1]
-];
+export let map = [];
+
+export function generateMap(width, height) {
+  // Initialize map filled with walls
+  map = Array.from({ length: height }, () => Array(width).fill(1));
+
+  const dirs = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+  ];
+
+  function inBounds(x, y) {
+    return x > 0 && y > 0 && x < width - 1 && y < height - 1;
+  }
+
+  function shuffle(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [array[i], array[j]] = [array[j], array[i]];
+    }
+  }
+
+  function carve(x, y) {
+    map[y][x] = 0;
+    const order = dirs.slice();
+    shuffle(order);
+    for (const [dx, dy] of order) {
+      const nx = x + dx * 2;
+      const ny = y + dy * 2;
+      if (inBounds(nx, ny) && map[ny][nx] === 1) {
+        map[y + dy][x + dx] = 0;
+        carve(nx, ny);
+      }
+    }
+  }
+
+  carve(1, 1);
+
+  // Ensure starting cells for Harry and Tom are open and connected
+  if (height > 2 && width > 10) {
+    map[1][1] = 0; // Harry
+    map[2][9] = 0; // path to Tom
+    map[2][10] = 0; // Tom
+  }
+}
 
 export function drawMap(ctx, tileSize, wallImage, floorImage) {
   for (let row = 0; row < map.length; row++) {
-        for (let col = 0; col < map[row].length; col++) {
-            const x = col * tileSize;
-            const y = row * tileSize;
+    for (let col = 0; col < map[row].length; col++) {
+      const x = col * tileSize;
+      const y = row * tileSize;
 
-            if (map[row][col] === 1) {
-                ctx.drawImage(wallImage, x, y, tileSize, tileSize);
-            } else {
-                ctx.drawImage(floorImage, x, y, tileSize, tileSize);
-            }
-        }
+      if (map[row][col] === 1) {
+        ctx.drawImage(wallImage, x, y, tileSize, tileSize);
+      } else {
+        ctx.drawImage(floorImage, x, y, tileSize, tileSize);
+      }
     }
+  }
 }


### PR DESCRIPTION
## Summary
- Switch to mutable `map` and implement `generateMap` to create a random connected maze with open starting cells
- Invoke `generateMap` on load and restart, resizing the canvas after each generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891e363cc78832b87460c246f6c7d85