### PR TITLE
Ensure dementors spawn near free tiles

### DIFF
--- a/js/dementor.js
+++ b/js/dementor.js
@@ -16,6 +16,16 @@ function isTooClosePoints(col, row, points, minDistance) {
   return points.some(p => Math.abs(p.x - col) + Math.abs(p.y - row) < minDistance);
 }
 
+function hasFreeNeighbor(col, row, map) {
+  const dirs = [
+    { dx: 0, dy: -1 },
+    { dx: 0, dy: 1 },
+    { dx: -1, dy: 0 },
+    { dx: 1, dy: 0 }
+  ];
+  return dirs.some(dir => map[row + dir.dy]?.[col + dir.dx] === 0);
+}
+
 export function generateDementors(image, map, tileSize, forbidden = [], minDistance = 1) {
   dementors = [];
   let count = 0;
@@ -29,6 +39,7 @@ export function generateDementors(image, map, tileSize, forbidden = [], minDista
 
     if (
       map[row][col] === 0 &&
+      hasFreeNeighbor(col, row, map) &&
       !isTooClose(col, row, dementors, minDistance, tileSize) &&
       !isTooClosePoints(col, row, forbidden, minDistance)
     ) {

--- a/tests/dementor.test.js
+++ b/tests/dementor.test.js
@@ -39,6 +39,50 @@ test('generateDementors creates three dementors on free tiles without overlap', 
   }
 });
 
+test('generateDementors places dementors only on tiles with a free neighbor', () => {
+  const originalRandom = Math.random;
+  const originalNow = performance.now;
+
+  try {
+    const randomValues = [0, 0, 0.3, 0.3, 0.6, 0.3, 0.3, 0.6];
+    let randIndex = 0;
+    Math.random = () => randomValues[randIndex++];
+
+    const perfValues = [0, 0, 0];
+    let perfIndex = 0;
+    performance.now = () => perfValues[perfIndex++];
+
+    const map = [
+      [0, 1, 1, 1],
+      [1, 0, 0, 1],
+      [1, 0, 1, 1],
+      [1, 1, 1, 1]
+    ];
+    const tileSize = 10;
+    const image = {};
+
+    generateDementors(image, map, tileSize);
+    const dementors = getDementors();
+
+    assert.equal(dementors.length, 3);
+    const dirs = [
+      [0, -1],
+      [0, 1],
+      [-1, 0],
+      [1, 0]
+    ];
+    dementors.forEach(d => {
+      const col = d.x / tileSize;
+      const row = d.y / tileSize;
+      const hasNeighbor = dirs.some(([dx, dy]) => map[row + dy]?.[col + dx] === 0);
+      assert.ok(hasNeighbor);
+    });
+  } finally {
+    Math.random = originalRandom;
+    performance.now = originalNow;
+  }
+});
+
 test('generateDementors respects forbidden positions and minDistance', () => {
   const originalRandom = Math.random;
   const originalNow = performance.now;


### PR DESCRIPTION
## Summary
- prevent spawning dementors on isolated tiles by checking for a free neighbor
- add test confirming each dementor starts next to an open tile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891e3685250832b960225e7f475d86e