### PR TITLE
Fix map redeclaration and simplify map generation

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1,4 +1,4 @@
-import { map, drawMap, generateMap } from './map.js';
+import { drawMap, generateMap } from './map.js';
 import { player } from './player.js';
 import { horcruxes, generateHorcruxes, drawHorcruxes, checkPickup } from './horcruxManager.js';
 import { tom, initTom, moveTom, drawTom, sayTomQuote, updateSpeechPosition, stopTomSpeech } from './tom.js';
@@ -108,7 +108,7 @@ window.onload = () => {
   loseDisplay = document.getElementById('loseCount');
   updateScoreboard();
 
-  generateMap(MAP_WIDTH, MAP_HEIGHT);
+  map = generateMap(MAP_WIDTH, MAP_HEIGHT);
   resizeCanvas();
   window.addEventListener('resize', resizeCanvas);
 
@@ -127,7 +127,7 @@ window.onload = () => {
 
 
   restartBtn.addEventListener('click', () => {
-    generateMap(MAP_WIDTH, MAP_HEIGHT);
+    map = generateMap(MAP_WIDTH, MAP_HEIGHT);
     resizeCanvas();
     player.init(harryImage, tileSize);
     initTom(tomImage, tileSize);

--- a/js/map.js
+++ b/js/map.js
@@ -1,58 +1,10 @@
-export let map = [];
-
-export function generateMap(width, height) {
-  // Initialize map filled with walls
-  map = Array.from({ length: height }, () => Array(width).fill(1));
-
-  const dirs = [
-    [1, 0],
-    [-1, 0],
-    [0, 1],
-    [0, -1],
-  ];
-
-  function inBounds(x, y) {
-    return x > 0 && y > 0 && x < width - 1 && y < height - 1;
-  }
-
-  function shuffle(array) {
-    for (let i = array.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [array[i], array[j]] = [array[j], array[i]];
-    }
-  }
-
-  function carve(x, y) {
-    map[y][x] = 0;
-    const order = dirs.slice();
-    shuffle(order);
-    for (const [dx, dy] of order) {
-      const nx = x + dx * 2;
-      const ny = y + dy * 2;
-      if (inBounds(nx, ny) && map[ny][nx] === 1) {
-        map[y + dy][x + dx] = 0;
-        carve(nx, ny);
-      }
-    }
-  }
-
-  carve(1, 1);
-
-  // Ensure starting cells for Harry and Tom are open and connected
-  if (height > 2 && width > 10) {
-    map[1][1] = 0; // Harry
-    map[2][9] = 0; // path to Tom
-    map[2][10] = 0; // Tom
-  }
-export function generateMap(rows = 14, cols = 12) {
-  const grid = Array.from({ length: rows }, (_, r) =>
+export function generateMap(cols = 12, rows = 15) {
+  return Array.from({ length: rows }, (_, r) =>
     Array.from({ length: cols }, (_, c) => {
       if (r === 0 || c === 0 || r === rows - 1 || c === cols - 1) return 1;
       return Math.random() < 0.3 ? 1 : 0;
     })
   );
-  return grid;
-
 }
 
 export function drawMap(ctx, tileSize, wallImage, floorImage, map) {
@@ -60,7 +12,6 @@ export function drawMap(ctx, tileSize, wallImage, floorImage, map) {
     for (let col = 0; col < map[row].length; col++) {
       const x = col * tileSize;
       const y = row * tileSize;
-
       if (map[row][col] === 1) {
         ctx.drawImage(wallImage, x, y, tileSize, tileSize);
       } else {


### PR DESCRIPTION
## Summary
- avoid redeclaring `map` in game logic by removing redundant import
- streamline map module to only export generation and drawing helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891f46d4f34832ba6f59f3f0a7ad8aa