### PR TITLE
Reduce diagonal walls in map generation

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -1,10 +1,52 @@
 export function generateMap(cols = 12, rows = 15) {
-  return Array.from({ length: rows }, (_, r) =>
+  const map = Array.from({ length: rows }, (_, r) =>
     Array.from({ length: cols }, (_, c) => {
       if (r === 0 || c === 0 || r === rows - 1 || c === cols - 1) return 1;
-      return Math.random() < 0.3 ? 1 : 0;
+      return Math.random() < 0.2 ? 1 : 0;
     })
   );
+
+  const isBorder = (r, c) => r === 0 || c === 0 || r === rows - 1 || c === cols - 1;
+
+  for (let r = 0; r < rows - 1; r++) {
+    for (let c = 0; c < cols - 1; c++) {
+      if (
+        map[r][c] === 1 &&
+        map[r + 1][c + 1] === 1 &&
+        map[r][c + 1] === 0 &&
+        map[r + 1][c] === 0
+      ) {
+        if (isBorder(r, c)) {
+          map[r + 1][c + 1] = 0;
+        } else if (isBorder(r + 1, c + 1)) {
+          map[r][c] = 0;
+        } else if (Math.random() < 0.5) {
+          map[r][c] = 0;
+        } else {
+          map[r + 1][c + 1] = 0;
+        }
+      }
+
+      if (
+        map[r][c + 1] === 1 &&
+        map[r + 1][c] === 1 &&
+        map[r][c] === 0 &&
+        map[r + 1][c + 1] === 0
+      ) {
+        if (isBorder(r, c + 1)) {
+          map[r + 1][c] = 0;
+        } else if (isBorder(r + 1, c)) {
+          map[r][c + 1] = 0;
+        } else if (Math.random() < 0.5) {
+          map[r][c + 1] = 0;
+        } else {
+          map[r + 1][c] = 0;
+        }
+      }
+    }
+  }
+
+  return map;
 }
 
 export function drawMap(ctx, tileSize, wallImage, floorImage, map) {


### PR DESCRIPTION
## Summary
- Lower random wall spawn probability to 20%
- Post-process maps to remove diagonal wall pairs without orthogonal walls while preserving borders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891ff7bf5f8832bb63255f032e4f671