### PR TITLE
Fix Tom movement with fractional step speeds

### DIFF
--- a/js/tom.js
+++ b/js/tom.js
@@ -34,7 +34,11 @@ export function moveTom(path, tileSize, steps = 1) {
     if (speaking || tom.isMoving || path.length === 0) return;
     const prevX = tom.x + tileSize / 2;
     const prevY = tom.y + tileSize / 2;
-    const step = path[Math.min(steps - 1, path.length - 1)];
+    const stepIndex = Math.min(
+        Math.max(0, Math.floor(steps) - 1),
+        path.length - 1
+    );
+    const step = path[stepIndex];
     tom.targetX = step.col * tileSize;
     tom.targetY = step.row * tileSize;
     tom.isMoving = true;

--- a/tests/tom.test.js
+++ b/tests/tom.test.js
@@ -40,7 +40,9 @@ describe('tom character', () => {
 
   beforeEach(() => {
     restoreTimers = setupFakeTimers();
-    global.requestAnimationFrame = () => {};
+    global.requestAnimationFrame = (fn) => {
+      fn(performance.now() + 200);
+    };
     div = { style: { display: 'none' }, innerText: '' };
     global.document = { getElementById: () => div };
     initTom({}, tileSize, 10, 2);
@@ -74,6 +76,12 @@ describe('tom character', () => {
     moveTom([{ col: 11, row: 2 }], tileSize);
     assert.equal(tom.x, initialX);
     assert.equal(tom.y, initialY);
+  });
+
+  it('moves even when steps less than 1', () => {
+    moveTom([{ col: 11, row: 2 }], tileSize, 0.5);
+    assert.equal(tom.x, 11 * tileSize);
+    assert.equal(tom.y, 2 * tileSize);
   });
 
   it('sayTomQuote shows and hides tomSpeech after timeout', () => {


### PR DESCRIPTION
## Summary
- prevent negative path indexing in Tom's movement when speed is fractional
- add regression test covering sub-tile step counts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68921cf042c8832b9397d3d7dcb4cb22