### PR TITLE
feat: support continuous swipe movement

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -187,26 +187,52 @@ function setupControls() {
   initButtonControls(onKey);
 
   let startX, startY;
+  let lastMove = 0;
+  const MOVE_DELAY = 100; // ms
 
-  canvas.addEventListener('touchstart', (e) => {
-    e.preventDefault();
-    const touch = e.touches[0];
-    startX = touch.clientX;
-    startY = touch.clientY;
-  }, { passive: false });
+  canvas.addEventListener(
+    'touchstart',
+    e => {
+      e.preventDefault();
+      const touch = e.touches[0];
+      startX = touch.clientX;
+      startY = touch.clientY;
+      lastMove = 0;
+    },
+    { passive: false }
+  );
 
-  canvas.addEventListener('touchend', (e) => {
-    e.preventDefault();
-    const touch = e.changedTouches[0];
-    const dx = touch.clientX - startX;
-    const dy = touch.clientY - startY;
+  canvas.addEventListener(
+    'touchmove',
+    e => {
+      e.preventDefault();
+      const touch = e.touches[0];
+      const now = Date.now();
+      if (now - lastMove < MOVE_DELAY) return;
+      const dx = touch.clientX - startX;
+      const dy = touch.clientY - startY;
 
-    if (Math.abs(dx) > Math.abs(dy)) {
-      onKey({ key: dx > 0 ? 'ArrowRight' : 'ArrowLeft' });
-    } else {
-      onKey({ key: dy > 0 ? 'ArrowDown' : 'ArrowUp' });
-    }
-  }, { passive: false });
+      if (Math.abs(dx) > Math.abs(dy)) {
+        onKey({ key: dx > 0 ? 'ArrowRight' : 'ArrowLeft' });
+      } else {
+        onKey({ key: dy > 0 ? 'ArrowDown' : 'ArrowUp' });
+      }
+
+      startX = touch.clientX;
+      startY = touch.clientY;
+      lastMove = now;
+    },
+    { passive: false }
+  );
+
+  canvas.addEventListener(
+    'touchend',
+    () => {
+      startX = null;
+      startY = null;
+    },
+    { passive: false }
+  );
 }
 
 function onKey(e) {


### PR DESCRIPTION
## Summary
- add throttled touchmove controls that trigger movement while swiping
- clear touch state on touchend to stop continuous motion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68926cbd4fd4832ba39a28f041de2236