### PR TITLE
feat: add on-screen movement controls

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -34,6 +34,41 @@ body {
     background-color: rgba(0, 0, 0, 0.6);
 }
 
+/* On-screen movement controls */
+#controls {
+    position: absolute;
+    bottom: 2vh;
+    right: 2vw;
+    display: grid;
+    grid-template-columns: repeat(3, 10vw);
+    grid-template-rows: repeat(3, 10vw);
+    max-width: 150px;
+    max-height: 150px;
+    gap: 1vw;
+    z-index: 30;
+}
+
+.control-btn {
+    background-color: rgba(0, 0, 0, 0.6);
+    border: 2px solid #d4af37;
+    color: #d4af37;
+    border-radius: 8px;
+    font-size: 5vw;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    touch-action: manipulation;
+}
+
+.control-btn.up { grid-column: 2; grid-row: 1; }
+.control-btn.left { grid-column: 1; grid-row: 2; }
+.control-btn.down { grid-column: 2; grid-row: 3; }
+.control-btn.right { grid-column: 3; grid-row: 2; }
+
+.control-btn:active {
+    background-color: #333;
+}
+
 /* Restart button styling */
 #restartBtn {
     display: none;

--- a/index.html
+++ b/index.html
@@ -15,6 +15,13 @@
         <div id="scoreboard">
             Wins: <span id="winCount">0</span> | Losses: <span id="loseCount">0</span>
         </div>
+
+        <div id="controls">
+            <button class="control-btn up" data-key="ArrowUp">▲</button>
+            <button class="control-btn left" data-key="ArrowLeft">◀</button>
+            <button class="control-btn down" data-key="ArrowDown">▼</button>
+            <button class="control-btn right" data-key="ArrowRight">▶</button>
+        </div>
     </div>
 
     <button id="restartBtn">Restart</button>

--- a/js/game.js
+++ b/js/game.js
@@ -231,6 +231,16 @@ function setupControls() {
     },
     { passive: false }
   );
+
+  document.querySelectorAll('#controls .control-btn').forEach(btn => {
+    const key = btn.dataset.key;
+    const handler = e => {
+      e.preventDefault();
+      onKey({ key });
+    };
+    btn.addEventListener('click', handler);
+    btn.addEventListener('touchstart', handler, { passive: false });
+  });
 }
 
 function onKey(e) {


### PR DESCRIPTION
## Summary
- add visual arrow buttons for moving the player
- wire up buttons to existing movement logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892fb8b344c832ba4fa036739f28a32