### PR TITLE
Style D-pad and reserve control space

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -40,24 +40,30 @@ body {
     bottom: 2vh;
     right: 2vw;
     display: grid;
-    grid-template-columns: repeat(3, 10vw);
-    grid-template-rows: repeat(3, 10vw);
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(3, 1fr);
+    width: 20vw;
+    height: 20vw;
     max-width: 150px;
     max-height: 150px;
-    gap: 1vw;
+    padding: 2vw;
+    box-sizing: border-box;
+    border-radius: 50%;
+    background-color: #d4af37;
     z-index: 30;
+    gap: 0;
 }
 
 .control-btn {
-    background-color: rgba(0, 0, 0, 0.6);
-    border: 2px solid #d4af37;
-    color: #d4af37;
-    border-radius: 8px;
+    background: transparent;
+    border: none;
+    color: #000;
     font-size: 5vw;
     display: flex;
     align-items: center;
     justify-content: center;
     touch-action: manipulation;
+    border-radius: 50%;
 }
 
 .control-btn.up { grid-column: 2; grid-row: 1; }
@@ -65,8 +71,8 @@ body {
 .control-btn.down { grid-column: 2; grid-row: 3; }
 .control-btn.right { grid-column: 3; grid-row: 2; }
 
-.control-btn:active {
-    background-color: #333;
+.control-btn.pressed {
+    background-color: rgba(255, 255, 255, 0.4);
 }
 
 /* Restart button styling */

--- a/js/game.js
+++ b/js/game.js
@@ -68,7 +68,11 @@ function resizeCanvas() {
   const cols = map[0].length;
   const rows = map.length;
   const dpr = window.devicePixelRatio || 1;
-  const newTileSize = Math.min(window.innerWidth / cols, window.innerHeight / rows);
+  const controls = document.getElementById('controls');
+  const controlSize = controls ? controls.offsetWidth : 0;
+  const availableWidth = window.innerWidth - controlSize;
+  const availableHeight = window.innerHeight - controlSize;
+  const newTileSize = Math.min(availableWidth / cols, availableHeight / rows);
   if (tileSize) {
     const scale = newTileSize / tileSize;
     if (player.x !== null) {
@@ -94,6 +98,11 @@ function resizeCanvas() {
   canvas.width = tileSize * cols * dpr;
   canvas.height = tileSize * rows * dpr;
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  const container = document.getElementById('gameContainer');
+  if (controls && container) {
+    container.style.paddingRight = `${controlSize}px`;
+    container.style.paddingBottom = `${controlSize}px`;
+  }
   if (assetsLoaded === TOTAL_ASSETS) {
     draw();
   }
@@ -234,12 +243,21 @@ function setupControls() {
 
   document.querySelectorAll('#controls .control-btn').forEach(btn => {
     const key = btn.dataset.key;
-    const handler = e => {
+    const press = e => {
       e.preventDefault();
+      btn.classList.add('pressed');
       onKey({ key });
     };
-    btn.addEventListener('click', handler);
-    btn.addEventListener('touchstart', handler, { passive: false });
+    const release = e => {
+      e.preventDefault();
+      btn.classList.remove('pressed');
+    };
+    btn.addEventListener('mousedown', press);
+    btn.addEventListener('touchstart', press, { passive: false });
+    btn.addEventListener('mouseup', release);
+    btn.addEventListener('mouseleave', release);
+    btn.addEventListener('touchend', release);
+    btn.addEventListener('touchcancel', release);
   });
 }
 


### PR DESCRIPTION
## Summary
- Shrink canvas area by reserving space for on-screen controls
- Restyle on-screen D-pad with gold circular background and pressed highlight
- Highlight D-pad buttons during mouse/touch input for clearer feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893235ae820832b9db89eb122473549