### PR TITLE
Add golden circular control pad with directional arrows

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -39,34 +39,61 @@ body {
     position: absolute;
     bottom: 2vh;
     right: 2vw;
-    display: grid;
-    grid-template-columns: repeat(3, 10vw);
-    grid-template-rows: repeat(3, 10vw);
+    width: 30vw;
+    height: 30vw;
     max-width: 150px;
     max-height: 150px;
-    gap: 1vw;
+    border-radius: 50%;
+    background-color: #d4af37;
+    background-image: 
+        linear-gradient(45deg, transparent 48%, #000 48%, #000 52%, transparent 52%),
+        linear-gradient(-45deg, transparent 48%, #000 48%, #000 52%, transparent 52%);
     z-index: 30;
+    overflow: hidden;
 }
 
-.control-btn {
-    background-color: rgba(0, 0, 0, 0.6);
-    border: 2px solid #d4af37;
-    color: #d4af37;
-    border-radius: 8px;
-    font-size: 5vw;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+#controls .control-btn {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background: transparent;
+    border: none;
     touch-action: manipulation;
 }
 
-.control-btn.up { grid-column: 2; grid-row: 1; }
-.control-btn.left { grid-column: 1; grid-row: 2; }
-.control-btn.down { grid-column: 2; grid-row: 3; }
-.control-btn.right { grid-column: 3; grid-row: 2; }
+#controls .control-btn.up {
+    clip-path: polygon(50% 50%, 0 0, 100% 0);
+}
 
-.control-btn:active {
-    background-color: #333;
+#controls .control-btn.right {
+    clip-path: polygon(50% 50%, 100% 0, 100% 100%);
+}
+
+#controls .control-btn.down {
+    clip-path: polygon(50% 50%, 100% 100%, 0 100%);
+}
+
+#controls .control-btn.left {
+    clip-path: polygon(50% 50%, 0 100%, 0 0);
+}
+
+#controls .control-btn::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 5vw;
+    color: #000;
+}
+
+#controls .control-btn.up::before { content: '▲'; }
+#controls .control-btn.right::before { content: '▶'; }
+#controls .control-btn.down::before { content: '▼'; }
+#controls .control-btn.left::before { content: '◀'; }
+
+#controls .control-btn:active {
+    background-color: rgba(0, 0, 0, 0.2);
 }
 
 /* Restart button styling */

--- a/index.html
+++ b/index.html
@@ -17,10 +17,10 @@
         </div>
 
         <div id="controls">
-            <button class="control-btn up" data-key="ArrowUp">▲</button>
-            <button class="control-btn left" data-key="ArrowLeft">◀</button>
-            <button class="control-btn down" data-key="ArrowDown">▼</button>
-            <button class="control-btn right" data-key="ArrowRight">▶</button>
+            <button class="control-btn up" data-key="ArrowUp"></button>
+            <button class="control-btn right" data-key="ArrowRight"></button>
+            <button class="control-btn down" data-key="ArrowDown"></button>
+            <button class="control-btn left" data-key="ArrowLeft"></button>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Add single circular D-pad control styled with golden background and black arrow segments
- Update styles to create gold circle split diagonally with black arrows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68932e59f03c832b9d63845b8a5a6559