### PR TITLE
Fix audio path for Tom quote

### DIFF
--- a/js/tom.js
+++ b/js/tom.js
@@ -12,15 +12,19 @@ const quotes = [
     "Я разорву тебя на кусочки, мальчишка.",
 ];
 
-const quoteSounds = [
-    new Audio('/assets/give.mp3'),
-    new Audio('/assets/mercy.mp3'),
-    new Audio('/assets/mine.mp3'),
-    new Audio('/assets/pay.mp3'),
-    new Audio('/assets/why_you_run.mp3'),
-    new Audio('/assets/better.mp3'),
-    new Audio('/assets/cuts.mp3'),
+const quoteSoundPaths = [
+    '/assets/give_me.mp3',
+    '/assets/mercy.mp3',
+    '/assets/mine.mp3',
+    '/assets/pay.mp3',
+    '/assets/why_you_run.mp3',
+    '/assets/better.mp3',
+    '/assets/cuts.mp3',
 ];
+
+const quoteSounds = quoteSoundPaths.map((path) =>
+    typeof Audio !== 'undefined' ? new Audio(path) : { play() {}, currentTime: 0 }
+);
 
 
 let speaking = false;

--- a/tests/tom.test.js
+++ b/tests/tom.test.js
@@ -88,6 +88,7 @@ describe('tom character', () => {
     sayTomQuote();
     assert.equal(div.style.display, 'block');
     global.advanceTimersByTime(2000);
+    global.advanceTimersByTime(500);
     assert.equal(div.style.display, 'none');
   });
 });


### PR DESCRIPTION
## Summary
- Update Tom's quote sounds to use give_me.mp3 and safely handle missing Audio in Node
- Adjust Tom speech test for delayed hide animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68938f4bbe50832ba8ad9d6644f7d6c5