### PR TITLE
Add difficulty modes with configurable game settings

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -10,6 +10,28 @@ body {
     position: relative;
 }
 
+#start-screen {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    background-color: #222;
+    padding: 20px;
+    border: 2px solid #d4af37;
+    border-radius: 8px;
+    z-index: 100;
+    color: #d4af37;
+}
+
+#start-screen select,
+#start-screen button {
+    font-size: 1rem;
+    padding: 0.5rem 1rem;
+}
+
 #gameContainer {
     position: relative;
     display: inline-block;

--- a/index.html
+++ b/index.html
@@ -8,6 +8,14 @@
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
+    <div id="start-screen">
+        <select id="difficulty">
+            <option value="easy">easy</option>
+            <option value="normal">normal</option>
+            <option value="hard">hard</option>
+        </select>
+        <button id="start-btn">Start</button>
+    </div>
 
     <div id="gameContainer">
         <canvas id="gameCanvas"></canvas>

--- a/js/dementor.js
+++ b/js/dementor.js
@@ -1,4 +1,6 @@
 let dementors = [];
+let moveDuration = 600;
+let moveCooldown = 1000;
 
 export function getDementors() {
   return dementors;
@@ -26,11 +28,22 @@ function hasFreeNeighbor(col, row, map) {
   return dirs.some(dir => map[row + dir.dy]?.[col + dir.dx] === 0);
 }
 
-export function generateDementors(image, map, tileSize, forbidden = [], minDistance = 1) {
+export function generateDementors(
+  image,
+  map,
+  tileSize,
+  forbidden = [],
+  minDistance = 1,
+  count = 3,
+  duration = 600,
+  cooldown = 1000
+) {
   dementors = [];
-  let count = 0;
+  moveDuration = duration;
+  moveCooldown = cooldown;
+  let placed = 0;
 
-  while (count < 3) {
+  while (placed < count) {
     const col = Math.floor(Math.random() * map[0].length);
     const row = Math.floor(Math.random() * map.length);
 
@@ -52,7 +65,7 @@ export function generateDementors(image, map, tileSize, forbidden = [], minDista
         isMoving: false,
         lastMoveTime: performance.now()
       });
-      count++;
+      placed++;
     }
   }
 }
@@ -60,7 +73,7 @@ export function generateDementors(image, map, tileSize, forbidden = [], minDista
 export function updateDementors(tileSize, map, player) {
   const now = performance.now();
   dementors.forEach(d => {
-    if (d.isMoving || now - d.lastMoveTime < 1000) return;
+    if (d.isMoving || now - d.lastMoveTime < moveCooldown) return;
 
     const directions = [
       { dx: 0, dy: -1 },
@@ -108,14 +121,13 @@ export function updateDementors(tileSize, map, player) {
       const startX = d.x;
       const startY = d.y;
       const startTime = performance.now();
-      const duration = 600;
 
       const animate = (time) => {
         const elapsed = time - startTime;
-        const t = Math.min(elapsed / duration, 1);
+        const t = Math.min(elapsed / moveDuration, 1);
         d.x = startX + (d.targetX - startX) * t;
         d.y = startY + (d.targetY - startY) * t;
-        if (elapsed < duration) {
+        if (elapsed < moveDuration) {
           requestAnimationFrame(animate);
         } else {
           d.x = d.targetX;

--- a/js/map.js
+++ b/js/map.js
@@ -1,8 +1,8 @@
-export function generateMap(cols = 12, rows = 15) {
+export function generateMap(cols = 12, rows = 15, wallChance = 0.2) {
   const map = Array.from({ length: rows }, (_, r) =>
     Array.from({ length: cols }, (_, c) => {
       if (r === 0 || c === 0 || r === rows - 1 || c === cols - 1) return 1;
-      return Math.random() < 0.2 ? 1 : 0;
+      return Math.random() < wallChance ? 1 : 0;
     })
   );
 

--- a/tests/difficulty.test.js
+++ b/tests/difficulty.test.js
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// stub required globals before importing game.js
+global.sessionStorage = {
+  data: {},
+  getItem(key) {
+    return this.data[key] || null;
+  },
+  setItem(key, value) {
+    this.data[key] = String(value);
+  }
+};
+global.window = { devicePixelRatio: 1, innerWidth: 800, innerHeight: 600, addEventListener: () => {} };
+
+const { DIFFICULTY_SETTINGS } = await import('../js/game.js');
+import { generateMap } from '../js/map.js';
+import { generateDementors, getDementors } from '../js/dementor.js';
+
+describe('difficulty settings', () => {
+  it('easy settings are correct', () => {
+    const easy = DIFFICULTY_SETTINGS.easy;
+    assert.equal(easy.mapWidth, 10);
+    assert.equal(easy.dementorCount, 2);
+    assert.equal(easy.tomSpeed, 0.6);
+    assert.equal(easy.wallChance, 0.15);
+  });
+
+  it('map respects wallChance parameter', () => {
+    const empty = generateMap(5, 5, 0);
+    for (let r = 1; r < 4; r++) {
+      for (let c = 1; c < 4; c++) {
+        assert.equal(empty[r][c], 0);
+      }
+    }
+    const full = generateMap(5, 5, 1);
+    for (let r = 1; r < 4; r++) {
+      for (let c = 1; c < 4; c++) {
+        assert.equal(full[r][c], 1);
+      }
+    }
+  });
+
+  it('generateDementors respects count', () => {
+    const map = Array.from({ length: 5 }, () => Array(5).fill(0));
+    // deterministic randomness
+    const values = [0.1, 0.3, 0.5, 0.7, 0.9];
+    let idx = 0;
+    const originalRandom = Math.random;
+    Math.random = () => {
+      const val = values[idx % values.length];
+      idx++;
+      return val;
+    };
+    generateDementors({}, map, 32, [], 1, 4);
+    Math.random = originalRandom;
+    assert.equal(getDementors().length, 4);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add start screen allowing difficulty selection
- configure game via DIFFICULTY_SETTINGS and apply to map, enemies and Tom
- show start screen after defeat and add tests for difficulty handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898cac5a43c832b83aa3430dd9c6774