### PR TITLE
Guard draw calls until sprites load

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -455,8 +455,12 @@ function draw() {
   drawMap(ctx, tileSize, wallImage, floorImage, map);
   drawHorcruxes(ctx, tileSize);
   drawDementors(ctx, tileSize);
-  player.draw(ctx, tileSize);
-  drawTom(ctx, tileSize);
+  if (player.image) {
+    player.draw(ctx, tileSize);
+  }
+  if (tom.image) {
+    drawTom(ctx, tileSize);
+  }
   updateAndDrawParticles(ctx);
   updateSpeechPosition(canvas, tileSize);
 


### PR DESCRIPTION
## Summary
- Avoid calling drawImage for player or Tom before their images are loaded by checking for image existence in the game loop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898dbe3e094832b8712a5895ce39c01