### PR TITLE
Center start screen panel and hide overflow

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -8,11 +8,14 @@ body {
     height: 100vh;
     font-family: sans-serif;
     position: relative;
+    overflow: hidden;
 }
 
 #start-screen {
-    position: absolute;
-    inset: 0;
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
     display: flex;
     flex-direction: column;
     justify-content: center;


### PR DESCRIPTION
## Summary
- Hide viewport scrolling and overflow on the body
- Use fixed centering for the start screen so difficulty panel stays centered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898e9848468832b9c25bca2a094adcd