### PR TITLE
feat: add graphical start screen

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -13,27 +13,30 @@ body {
 
 #start-screen {
     position: fixed;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
     display: flex;
-    flex-direction: column;
-    justify-content: center;
+    justify-content: flex-end;
     align-items: center;
-    gap: 2rem;
-    background: radial-gradient(circle, #222 0%, #000 100%);
+    background: url('../assets/start.png') no-repeat center center/cover;
     color: #d4af37;
     z-index: 100;
 }
 
-#start-screen h1 {
-    margin: 0;
-    font-size: 2rem;
-    color: #d4af37;
+#start-menu {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 10vh;
+    background-color: rgba(0, 0, 0, 0.6);
+    padding: 1rem 2rem;
+    border-radius: 8px;
 }
 
-#start-screen select,
-#start-screen button {
+#start-menu select,
+#start-menu button {
     font-size: 1.2rem;
     padding: 0.75rem 1.5rem;
     background-color: transparent;
@@ -42,8 +45,8 @@ body {
     border-radius: 8px;
 }
 
-#start-screen select:hover,
-#start-screen button:hover {
+#start-menu select:hover,
+#start-menu button:hover {
     background-color: rgba(212, 175, 55, 0.1);
 }
 

--- a/index.html
+++ b/index.html
@@ -9,13 +9,14 @@
 </head>
 <body>
     <div id="start-screen">
-        <h1>Choose difficulty</h1>
-        <select id="difficulty">
-            <option value="easy">Easy</option>
-            <option value="normal" selected>Normal</option>
-            <option value="hard">Hard</option>
-        </select>
-        <button id="start-btn">Start</button>
+        <div id="start-menu">
+            <select id="difficulty">
+                <option value="easy">Easy</option>
+                <option value="normal" selected>Normal</option>
+                <option value="hard">Hard</option>
+            </select>
+            <button id="start-btn">Play</button>
+        </div>
     </div>
 
     <div id="gameContainer">


### PR DESCRIPTION
## Summary
- use `start.png` as full-screen start menu background
- center difficulty selector and new **Play** button on start screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899d65b8340832b8c51bd587e47ba75