### PR TITLE
Move difficulty selector to bottom of start screen

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -18,8 +18,8 @@ body {
     width: 100%;
     height: 100%;
     display: flex;
-    justify-content: flex-end;
-    align-items: center;
+    justify-content: center;
+    align-items: flex-end;
     background: url('../assets/start.png') no-repeat center center/cover;
     color: #d4af37;
     z-index: 100;


### PR DESCRIPTION
## Summary
- Align start menu to bottom center so level picker sits near the bottom of the start screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899d87ef004832b9918050df0cec40c