### PR TITLE
Show win/lose screens with restart option

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         </div>
     </div>
 
-    <button id="restartBtn">Restart</button>
+    <button id="restartBtn">Начать заново</button>
     <div id="tomSpeech"></div>
 
     <!-- Подключаем модули -->

--- a/js/game.js
+++ b/js/game.js
@@ -97,12 +97,6 @@ function setGameState(state) {
     sessionStorage.setItem('losses', loseCount);
     loseSound.currentTime = 0;
     loseSound.play().catch(() => {});
-    const startScreen = document.getElementById('start-screen');
-    const diffSelect = document.getElementById('difficulty');
-    if (startScreen && diffSelect) {
-      startScreen.style.display = 'block';
-      diffSelect.value = sessionStorage.getItem('difficulty') || currentDifficulty;
-    }
   }
   updateScoreboard();
 }
@@ -269,18 +263,15 @@ export function startGame(difficulty) {
 }
 
 function restartGame() {
-  generateLevel();
-  resizeCanvas();
-  if (!resizeBound) {
-    window.addEventListener('resize', resizeCanvas);
-    resizeBound = true;
+  const startScreen = document.getElementById('start-screen');
+  const diffSelect = document.getElementById('difficulty');
+  if (startScreen && diffSelect) {
+    startScreen.style.display = 'block';
+    diffSelect.value = sessionStorage.getItem('difficulty') || currentDifficulty;
   }
-  if (assetsLoaded === TOTAL_ASSETS) {
-    setupGame();
-    setGameState('playing');
-    restartBtn.style.display = 'none';
-    stopTomSpeech();
-  }
+  restartBtn.style.display = 'none';
+  stopTomSpeech();
+  gameState = 'start';
 }
 
 export function initDifficulty() {
@@ -477,7 +468,7 @@ function draw() {
   } else if (gameState === 'lose') {
     stopTomSpeech();
     ctx.drawImage(loseImage, 0, 0, displayWidth, displayHeight);
-    restartBtn.style.display = 'none';
+    restartBtn.style.display = 'block';
   } else {
     restartBtn.style.display = 'none';
   }


### PR DESCRIPTION
## Summary
- Display win/lose screens instead of immediately showing the start menu
- Add "Начать заново" button on result screens that returns to the start screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899dac9ba1c832b9404096dd3984c40