### PR TITLE
Refine Tom movement speed

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -415,7 +415,7 @@ function startTomLoop() {
       map
     );
     moveTom(path, tileSize, tomSpeed);
-  }, 300);
+  }, 300 / tomSpeed);
 }
 
 const activeDementorCollisions = new Set();

--- a/js/tom.js
+++ b/js/tom.js
@@ -29,6 +29,7 @@ const quoteSounds = quoteSoundPaths.map((path) =>
 
 let speaking = false;
 let speechTimer = null;
+let stepAccumulator = 0;
 
 export function initTom(img, tileSize, startCol = 10, startRow = 2) {
     tom.image = img;
@@ -42,14 +43,19 @@ export function initTom(img, tileSize, startCol = 10, startRow = 2) {
         clearTimeout(speechTimer);
         speechTimer = null;
     }
+    stepAccumulator = 0;
 }
 
 export function moveTom(path, tileSize, steps = 1) {
     if (speaking || tom.isMoving || path.length === 0) return;
+    stepAccumulator += steps;
+    const stepsToTake = Math.floor(stepAccumulator);
+    if (stepsToTake <= 0) return;
+    stepAccumulator -= stepsToTake;
     const prevX = tom.x + tileSize / 2;
     const prevY = tom.y + tileSize / 2;
     const stepIndex = Math.min(
-        Math.max(0, Math.floor(steps) - 1),
+        Math.max(0, stepsToTake - 1),
         path.length - 1
     );
     const step = path[stepIndex];

--- a/tests/tom.test.js
+++ b/tests/tom.test.js
@@ -89,7 +89,13 @@ describe('tom character', () => {
     assert.equal(tom.y, initialY);
   });
 
-  it('moves even when steps less than 1', () => {
+  it('accumulates fractional steps before moving', () => {
+    const { x: initialX, y: initialY } = tom;
+    moveTom([{ col: 11, row: 2 }], tileSize, 0.5);
+    // Not enough accumulated steps, position should remain unchanged
+    assert.equal(tom.x, initialX);
+    assert.equal(tom.y, initialY);
+    // Second call accumulates to 1.0 and triggers movement
     moveTom([{ col: 11, row: 2 }], tileSize, 0.5);
     assert.equal(tom.x, 11 * tileSize);
     assert.equal(tom.y, 2 * tileSize);


### PR DESCRIPTION
## Summary
- Drive Tom's move interval by `tomSpeed`, giving faster difficulties quicker pursuit
- Handle fractional Tom speeds by accumulating steps before moving
- Update tests for Tom's movement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899da352b34832bb3a3afc56a690291