### PR TITLE
feat: add buffered movement

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -373,25 +373,27 @@ function onKey(e) {
     case 'ArrowRight': dx = tileSize; break;
     default: return; // Ignore other keys
   }
+  const moved = player.move(dx, dy, tileSize, map, handlePlayerMove);
+  handlePlayerMove(moved);
+}
 
-  const moved = player.move(dx, dy, tileSize, map);
-  if (moved) {
-    const allCollected = checkPickup(moved.col, moved.row, () => {
-      if (gameState === 'playing') {
-        sayTomQuote();
-      }
-    });
+function handlePlayerMove(moved) {
+  if (!moved) return;
+  const allCollected = checkPickup(moved.col, moved.row, () => {
+    if (gameState === 'playing') {
+      sayTomQuote();
+    }
+  });
 
-    if (allCollected) {
-      setGameState('win');
-    }
-    if (
-      !tom.isMoving &&
-      Math.floor(tom.x / tileSize) === Math.floor(player.x / tileSize) &&
-      Math.floor(tom.y / tileSize) === Math.floor(player.y / tileSize)
-    ) {
-      setGameState('lose');
-    }
+  if (allCollected) {
+    setGameState('win');
+  }
+  if (
+    !tom.isMoving &&
+    Math.floor(tom.x / tileSize) === Math.floor(player.x / tileSize) &&
+    Math.floor(tom.y / tileSize) === Math.floor(player.y / tileSize)
+  ) {
+    setGameState('lose');
   }
 }
 

--- a/js/player.js
+++ b/js/player.js
@@ -9,15 +9,20 @@ export const player = {
   targetX: null,
   targetY: null,
   isMoving: false,
+  queuedMove: null,
   image: null,
   init(img, tileSize, startCol = 1, startRow = 1) {
     this.image = img;
     this.x = this.targetX = startCol * tileSize;
     this.y = this.targetY = startRow * tileSize;
     this.isMoving = false;
+    this.queuedMove = null;
   },
-  move(dx, dy, tileSize, map) {
-    if (this.isMoving) return null;
+  move(dx, dy, tileSize, map, onComplete) {
+    if (this.isMoving) {
+      this.queuedMove = { dx, dy };
+      return null;
+    }
     const tentativeX = this.x + dx;
     const tentativeY = this.y + dy;
     const col = Math.floor(tentativeX / tileSize);
@@ -62,6 +67,12 @@ export const player = {
           this.x = this.targetX;
           this.y = this.targetY;
           this.isMoving = false;
+          if (onComplete) onComplete({ col, row });
+          if (this.queuedMove) {
+            const next = this.queuedMove;
+            this.queuedMove = null;
+            this.move(next.dx, next.dy, tileSize, map, onComplete);
+          }
         }
       };
       requestAnimationFrame(animate);


### PR DESCRIPTION
## Summary
- queue last direction during movement
- auto execute buffered movement step when animation ends
- centralize player step side effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899da35fc3c832b9c9070db32666bf2