### PR TITLE
Clear old dementor collisions on new level generation

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -254,6 +254,7 @@ export function startGame(difficulty) {
   moveDuration = currentSettings.moveDuration;
   moveCooldown = currentSettings.moveCooldown;
   startRequested = true;
+  activeDementorCollisions.clear();
   generateLevel();
   resizeCanvas();
   if (!resizeBound) {
@@ -269,6 +270,7 @@ export function startGame(difficulty) {
 }
 
 function restartGame() {
+  activeDementorCollisions.clear();
   generateLevel();
   resizeCanvas();
   if (!resizeBound) {


### PR DESCRIPTION
## Summary
- reset active dementor collision tracking before generating new levels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899da3737c4832b9cc10ec6ba7c2be6