### PR TITLE
Allow customizing dementor initial delay

### DIFF
--- a/js/dementor.js
+++ b/js/dementor.js
@@ -36,7 +36,8 @@ export function generateDementors(
   minDistance = 1,
   count = 3,
   duration = 600,
-  cooldown = 1000
+  cooldown = 1000,
+  initialDelay = cooldown
 ) {
   dementors = [];
   moveDuration = duration;
@@ -63,7 +64,7 @@ export function generateDementors(
         targetX: px,
         targetY: py,
         isMoving: false,
-        lastMoveTime: performance.now()
+        lastMoveTime: performance.now() - moveCooldown + initialDelay
       });
       placed++;
     }

--- a/js/game.js
+++ b/js/game.js
@@ -228,7 +228,8 @@ function setupGame() {
     MIN_DISTANCE,
     dementorCount,
     moveDuration,
-    moveCooldown
+    moveCooldown,
+    0
   );
   if (!controlsInitialized) {
     setupControls();


### PR DESCRIPTION
## Summary
- Add optional `initialDelay` parameter to `generateDementors` to control when dementors start moving
- Start levels with zero initial delay so dementors move immediately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899da381efc832b9ce70c5ea1a8f2a6