### PR TITLE
Fix missing semicolons after clearing active dementor collisions

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -249,7 +249,7 @@ export function startGame(difficulty) {
   moveDuration = currentSettings.moveDuration;
   moveCooldown = currentSettings.moveCooldown;
   startRequested = true;
-  activeDementorCollisions.clear ()
+  activeDementorCollisions.clear();
   generateLevel();
   resizeCanvas();
   if (!resizeBound) {
@@ -272,7 +272,7 @@ function restartGame() {
     diffSelect.value = sessionStorage.getItem('difficulty') || currentDifficulty;
   }
   restartBtn.style.display = 'none';
-  activeDementorCollisions.clear ()
+  activeDementorCollisions.clear();
   stopTomSpeech();
   gameState = 'start';
 }


### PR DESCRIPTION
## Summary
- Add semicolons for `activeDementorCollisions.clear()` calls in game initialization and restart logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e2949bc0832b895133d920caae50