### PR TITLE
Reset particles when starting or restarting game

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -3,7 +3,12 @@ import { player } from './player.js';
 import { horcruxes, generateHorcruxes, drawHorcruxes, checkPickup } from './horcruxManager.js';
 import { tom, initTom, moveTom, drawTom, sayTomQuote, updateSpeechPosition, stopTomSpeech } from './tom.js';
 import { findPath } from './pathfinding.js';
-import { updateAndDrawParticles, particles, spawnParticles } from './particle.js';
+import {
+  updateAndDrawParticles,
+  particles,
+  spawnParticles,
+  clearParticles
+} from './particle.js';
 import { generateDementors, drawDementors, updateDementors, getDementors } from './dementor.js';
 
 let canvas, ctx;
@@ -237,6 +242,7 @@ function setupGame() {
 }
 
 export function startGame(difficulty) {
+  clearParticles();
   currentDifficulty = difficulty;
   currentSettings = DIFFICULTY_SETTINGS[currentDifficulty];
   tomSpeed = currentSettings.tomSpeed;
@@ -265,6 +271,7 @@ export function startGame(difficulty) {
 }
 
 function restartGame() {
+  clearParticles();
   const startScreen = document.getElementById('start-screen');
   const diffSelect = document.getElementById('difficulty');
   if (startScreen && diffSelect) {

--- a/js/particle.js
+++ b/js/particle.js
@@ -31,6 +31,10 @@ export class Particle {
 
 export const particles = [];
 
+export function clearParticles() {
+  particles.length = 0;
+}
+
 export function spawnParticles(x, y, character, dx = 0, dy = 0) {
   const colors = character === 'tom' ? ['green', 'silver'] : ['red', 'gold'];
   const mag = Math.sqrt(dx * dx + dy * dy) || 1;


### PR DESCRIPTION
## Summary
- export `clearParticles` helper to empty particle array
- reset particle effects when starting or restarting the game

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e2989280832bb71ec611b1eee7b8