### PR TITLE
Move level menu toward bottom edge

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -29,7 +29,7 @@ body {
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    margin-bottom: 10vh;
+    margin-bottom: 2vh;
     background-color: rgba(0, 0, 0, 0.6);
     padding: 1rem 2rem;
     border-radius: 8px;


### PR DESCRIPTION
## Summary
- Move start screen's difficulty menu closer to bottom of viewport

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e5746f84832b8b507c647ceb8941