### PR TITLE
Refactor player movement callback handling

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -392,8 +392,7 @@ function onKey(e) {
     case 'ArrowRight': dx = tileSize; break;
     default: return; // Ignore other keys
   }
-  const moved = player.move(dx, dy, tileSize, map, handlePlayerMove);
-  handlePlayerMove(moved);
+  player.move(dx, dy, tileSize, map, handlePlayerMove);
 }
 
 function handlePlayerMove(moved) {

--- a/tests/player.test.js
+++ b/tests/player.test.js
@@ -99,4 +99,11 @@ describe('player.move', () => {
     assert.strictEqual(player.x, tileSize);
     assert.strictEqual(player.y, tileSize);
   });
+
+  it('invokes onComplete callback once when move finishes', () => {
+    const onComplete = mock.fn();
+    player.move(tileSize, 0, tileSize, emptyMap, onComplete);
+    assert.strictEqual(onComplete.mock.callCount(), 1);
+    assert.deepStrictEqual(onComplete.mock.calls[0].arguments[0], { col: 2, row: 1 });
+  });
 });


### PR DESCRIPTION
## Summary
- Remove immediate `handlePlayerMove` invocation; rely on `player.move` callback
- Add unit test ensuring move completion triggers onComplete once

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a282cb48c832b9928a8d88b62f855