### PR TITLE
Add restart and menu buttons to end screen

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -113,41 +113,60 @@ body {
 
 .control-btn:active { background-color: #333; }
 
-/* ===== Restart button ===== */
-#restartBtn {
+/* ===== End buttons ===== */
+#endButtons {
   display: none;
   position: absolute;
   top: 60vh;
   left: 50%;
   transform: translate(-50%, -50%);
-  padding: 2vh 8vw 2vh 12vw;
-  font-size: 3vh;
-  font-family: inherit;
-  cursor: pointer;
   z-index: 40;
+  gap: 2vw;
+}
+
+#endButtons button {
   background-color: #222;
   border: 2px solid #d4af37;
   color: #d4af37;
   border-radius: 8px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background-color 0.3s, transform 0.3s;
+}
+
+#restartBtn {
+  padding: 2vh 8vw 2vh 12vw;
+  font-size: 3vh;
   background-image: url('../assets/ring.png');
   background-repeat: no-repeat;
   background-size: 6vh 6vh;
   background-position: 3vw center;
-  transition: background-color 0.3s, transform 0.3s;
 }
 
-#restartBtn:hover {
+#menuBtn {
+  padding: 2vh 8vw;
+  font-size: 3vh;
+}
+
+#restartBtn:hover,
+#menuBtn:hover {
   background-color: #333;
-  transform: translate(-50%, -50%) scale(1.05);
+  transform: scale(1.05);
 }
 
 @media (max-width: 600px) {
-  #restartBtn {
+  #endButtons {
     top: 55vh;
+  }
+  #restartBtn {
     padding: 2vh 10vw 2vh 16vw;
     font-size: 2.5vh;
     background-size: 5vh 5vh;
     background-position: 5vw center;
+  }
+  #menuBtn {
+    padding: 2vh 10vw;
+    font-size: 2.5vh;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -34,7 +34,10 @@
         </div>
     </div>
 
-    <button id="restartBtn">Restart</button>
+    <div id="endButtons">
+        <button id="restartBtn">Restart</button>
+        <button id="menuBtn">Back to Menu</button>
+    </div>
     <div id="tomSpeech"></div>
 
     <!-- Подключаем модули -->

--- a/js/game.js
+++ b/js/game.js
@@ -35,7 +35,9 @@ let snakeImage, diademImage, diaryImage, locketImage, ringImage;
 let winImage, loseImage;
 let winSound, loseSound;
 let dementorImage;
+let endButtons;
 let restartBtn;
+let menuBtn;
 let tomInterval;
 
 export const DIFFICULTY_SETTINGS = {
@@ -174,7 +176,9 @@ function resizeCanvas() {
 window.onload = () => {
   canvas = document.getElementById('gameCanvas');
   ctx = canvas.getContext('2d');
+  endButtons = document.getElementById('endButtons');
   restartBtn = document.getElementById('restartBtn');
+  menuBtn = document.getElementById('menuBtn');
   winDisplay = document.getElementById('winCount');
   loseDisplay = document.getElementById('loseCount');
   updateScoreboard();
@@ -203,6 +207,7 @@ window.onload = () => {
     : { play: () => Promise.resolve(), currentTime: 0 };
 
   restartBtn.addEventListener('click', restartGame);
+  menuBtn.addEventListener('click', returnToMenu);
 
   initDifficulty();
 };
@@ -284,11 +289,11 @@ export function startGame(difficulty) {
     setupGame();
   }
   setGameState('playing');
-  restartBtn.style.display = 'none';
+  endButtons.style.display = 'none';
   stopTomSpeech();
 }
 
-function restartGame() {
+function returnToMenu() {
   clearParticles();
   const startScreen = document.getElementById('start-screen');
   const diffSelect = document.getElementById('difficulty');
@@ -296,10 +301,14 @@ function restartGame() {
     startScreen.style.display = 'block';
     diffSelect.value = sessionStorage.getItem('difficulty') || currentDifficulty;
   }
-  restartBtn.style.display = 'none';
+  endButtons.style.display = 'none';
   activeDementorCollisions.clear();
   stopTomSpeech();
   gameState = 'start';
+}
+
+function restartGame() {
+  startGame(currentDifficulty);
 }
 
 export function initDifficulty() {
@@ -493,13 +502,13 @@ function draw() {
   if (gameState === 'win') {
     stopTomSpeech();
     ctx.drawImage(winImage, 0, 0, displayWidth, displayHeight);
-    restartBtn.style.display = 'block';
+    endButtons.style.display = 'flex';
   } else if (gameState === 'lose') {
     stopTomSpeech();
     ctx.drawImage(loseImage, 0, 0, displayWidth, displayHeight);
-    restartBtn.style.display = 'block';
+    endButtons.style.display = 'flex';
   } else {
-    restartBtn.style.display = 'none';
+    endButtons.style.display = 'none';
   }
 }
 

--- a/tests/buttons.test.js
+++ b/tests/buttons.test.js
@@ -1,0 +1,101 @@
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const startGameMock = mock.fn();
+globalThis.__startGameMock = startGameMock;
+const noop = () => {};
+globalThis.__mocks = {
+  drawMap: noop,
+  generateMap: noop,
+  player: {},
+  horcruxes: [],
+  generateHorcruxes: noop,
+  drawHorcruxes: noop,
+  checkPickup: noop,
+  tom: {},
+  initTom: noop,
+  moveTom: noop,
+  drawTom: noop,
+  sayTomQuote: noop,
+  updateSpeechPosition: noop,
+  stopTomSpeech: noop,
+  findPath: () => [],
+  updateAndDrawParticles: noop,
+  particles: [],
+  spawnParticles: noop,
+  clearParticles: noop,
+  generateDementors: noop,
+  drawDementors: noop,
+  updateDementors: noop,
+  getDementors: () => []
+};
+
+// Global stubs
+global.window = { devicePixelRatio:1, innerWidth:800, innerHeight:600, addEventListener: () => {} };
+global.sessionStorage = {
+  data: {},
+  getItem(key){ return this.data[key]; },
+  setItem(key, val){ this.data[key] = String(val); }
+};
+global.Audio = class { constructor(){ this.currentTime = 0; } play(){ return Promise.resolve(); } };
+global.Image = class { set src(v){ if (this.onload) this.onload(); } };
+
+let code = await fs.readFile(new URL('../js/game.js', import.meta.url), 'utf8');
+code = code
+  .replace("import { drawMap, generateMap } from './map.js';", "const { drawMap, generateMap } = globalThis.__mocks;")
+  .replace("import { player } from './player.js';", "const { player } = globalThis.__mocks;")
+  .replace("import { horcruxes, generateHorcruxes, drawHorcruxes, checkPickup } from './horcruxManager.js';", "const { horcruxes, generateHorcruxes, drawHorcruxes, checkPickup } = globalThis.__mocks;")
+  .replace("import { tom, initTom, moveTom, drawTom, sayTomQuote, updateSpeechPosition, stopTomSpeech } from './tom.js';", "const { tom, initTom, moveTom, drawTom, sayTomQuote, updateSpeechPosition, stopTomSpeech } = globalThis.__mocks;")
+  .replace("import { findPath } from './pathfinding.js';", "const { findPath } = globalThis.__mocks;")
+  .replace("import {\n  updateAndDrawParticles,\n  particles,\n  spawnParticles,\n  clearParticles\n} from './particle.js';", "const { updateAndDrawParticles, particles, spawnParticles, clearParticles } = globalThis.__mocks;")
+  .replace("import { generateDementors, drawDementors, updateDementors, getDementors } from './dementor.js';", "const { generateDementors, drawDementors, updateDementors, getDementors } = globalThis.__mocks;")
+  .replace(/export function startGame\([^]*?\n}\n/, 'export const startGame = globalThis.__startGameMock;\n')
+  + "\nexport const __test = { setCurrentDifficulty: d => currentDifficulty = d };";
+const url = 'data:text/javascript;base64,' + Buffer.from(code).toString('base64');
+const game = await import(url);
+delete globalThis.__mocks;
+delete globalThis.__startGameMock;
+
+let restartBtn, menuBtn, startScreen, diffSelect, endButtons;
+
+beforeEach(() => {
+  // reset session storage
+  sessionStorage.data = {};
+
+  restartBtn = { style: { display: 'none' }, addEventListener(event, handler){ this.handler = handler; } };
+  menuBtn = { style: { display: 'none' }, addEventListener(event, handler){ this.handler = handler; } };
+  endButtons = { style: { display: 'none' } };
+  startScreen = { style: { display: 'none' } };
+  diffSelect = { value: 'normal' };
+
+  const elements = {
+    gameCanvas: { getContext: () => ({}) },
+    restartBtn,
+    menuBtn,
+    endButtons,
+    'start-screen': startScreen,
+    difficulty: diffSelect,
+    'start-btn': { addEventListener: () => {} },
+    winCount: { textContent: '' },
+    loseCount: { textContent: '' }
+  };
+  global.document = { getElementById: id => elements[id] };
+
+  if (typeof window.onload === 'function') window.onload();
+  startGameMock.mock.resetCalls();
+});
+
+describe('end buttons', () => {
+  it('clicking restartBtn calls startGame with current difficulty', () => {
+    game.__test.setCurrentDifficulty('hard');
+    restartBtn.handler();
+    assert.strictEqual(startGameMock.mock.callCount(), 1);
+    assert.strictEqual(startGameMock.mock.calls[0].arguments[0], 'hard');
+  });
+
+  it('menuBtn makes the start screen visible again', () => {
+    menuBtn.handler();
+    assert.strictEqual(startScreen.style.display, 'block');
+  });
+});


### PR DESCRIPTION
## Summary
- Replace single restart button with restart and menu controls
- Hide/show end buttons based on game outcome and handle restarting
- Test end buttons for restarting and returning to menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a38d53a08832b8efbb48e73ef4186