### PR TITLE
Shrink Tom's speech bubble text

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -175,11 +175,11 @@ body {
   position: absolute;
   background: radial-gradient(circle at center, #f5f5f5 0%, #d9d9d9 70%, #bcbcbc 100%);
   color: #333;
-  padding: 8px 16px;
+  padding: 4px 8px;
   border-radius: 40px;
   box-shadow: 0 0 20px rgba(0,0,0,0.3);
   display: none;
-  font-size: 16px;
+  font-size: 12px;
   pointer-events: none;
   z-index: 999;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- Reduce Tom's speech bubble padding and font size to keep quotes from covering the play area

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a40bf9b18832ba90a3b01deeb3404