### PR TITLE
Avoid path recalculation while Tom is moving

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -435,6 +435,7 @@ function startTomLoop() {
   tomInterval = setInterval(() => {
     if (gameState !== 'playing') return;
     if (pathfindingPromise) return;
+    if (tom.isMoving) return;
     if (
       !tom.isMoving &&
       Math.floor(tom.x / tileSize) === Math.floor(player.x / tileSize) &&


### PR DESCRIPTION
## Summary
- Prevent Tom from starting a new path search while he is already moving by adding a movement guard in `startTomLoop`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b97b067dc832b803ffc7f7622ba19