### PR TITLE
Move on-screen controls below game area

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -82,9 +82,10 @@ body {
 
 /* ===== On-screen controls ===== */
 #controls {
-  position: absolute;
+  position: fixed;
   bottom: 2vh;
-  right: 2vw;
+  left: 50%;
+  transform: translateX(-50%);
   display: grid;
   grid-template-columns: repeat(3, 10vw);
   grid-template-rows: repeat(3, 10vw);

--- a/index.html
+++ b/index.html
@@ -26,12 +26,13 @@
             Wins: <span id="winCount">0</span> | Losses: <span id="loseCount">0</span>
         </div>
 
-        <div id="controls">
-            <button class="control-btn up" data-key="ArrowUp">▲</button>
-            <button class="control-btn left" data-key="ArrowLeft">◀</button>
-            <button class="control-btn down" data-key="ArrowDown">▼</button>
-            <button class="control-btn right" data-key="ArrowRight">▶</button>
-        </div>
+    </div>
+
+    <div id="controls">
+        <button class="control-btn up" data-key="ArrowUp">▲</button>
+        <button class="control-btn left" data-key="ArrowLeft">◀</button>
+        <button class="control-btn down" data-key="ArrowDown">▼</button>
+        <button class="control-btn right" data-key="ArrowRight">▶</button>
     </div>
 
     <div id="endButtons">


### PR DESCRIPTION
## Summary
- Position on-screen controls outside the `#gameContainer` so they render after the canvas.
- Style control panel with fixed bottom-center placement for consistent layout.

## Testing
- `npm test`
- ⚠️ Unable to run a browser to visually verify controls due to missing headless browser in container.


------
https://chatgpt.com/codex/tasks/task_e_689b98c86598832b9d97971d319ab2e4